### PR TITLE
Add terraform icons

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1229,6 +1229,18 @@ local icons = {
     cterm_color = "58",
     name = "Tex",
   },
+  ["tf"] = {
+    icon = "",
+    color = "#5F43E9",
+    cterm_color = "57",
+    name = "Terraform",
+  },
+  ["tfvars"] = {
+    icon = "",
+    color = "#5F43E9",
+    cterm_color = "57",
+    name = "TFVars",
+  },
   ["toml"] = {
     icon = "",
     color = "#6d8086",


### PR DESCRIPTION
This PR adds icons for `.tf` and `.tfvars`.

I considered `nf-fae-mountains ()`  vs `nf-mdi-terrain (行)` but decided to use the former since it's only 1 character wide.

![image](https://user-images.githubusercontent.com/190107/201634441-3042e9ae-8a95-417f-a8e0-bb85755bfbe9.png)
