### PR TITLE
Update kotlin logo color

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -754,14 +754,14 @@ local icons = {
   },
   ["kt"] = {
     icon = "",
-    color = "#F88A02",
-    cterm_color = "208",
+    color = "#7F52FF",
+    cterm_color = "99",
     name = "Kotlin",
   },
   ["kts"] = {
     icon = "",
-    color = "#F88A02",
-    cterm_color = "208",
+    color = "#7F52FF",
+    cterm_color = "99",
     name = "KotlinScript",
   },
   ["leex"] = {


### PR DESCRIPTION
This updates the kotlin logo to use the official color of the one-color logo that can be found [here](https://kotlinlang.org/docs/kotlin-brand-assets.html).