### PR TITLE
Add support for "Containerfile"

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -153,6 +153,12 @@ local icons = {
     cterm_color = "59",
     name = "GitCommit",
   },
+  ["Containerfile"] = {
+    icon = "",
+    color = "#384d54",
+    cterm_color = "59",
+    name = "Dockerfile",
+  },
   ["COPYING"] = {
     icon = "",
     color = "#cbcb41",


### PR DESCRIPTION
Vim recognizes `Containerfile`s as the `dockerfile` filetype. Since they can share the icon with Dockerfiles, I didn't add a separate filetype for them. If that's insufficient, let me know and I'll change it.