### PR TITLE
feat: map gql

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -608,6 +608,12 @@ local icons = {
     cterm_color = "199",
     name = "GraphQL"
   },
+  ["gql"] = {
+    icon = "",
+    color = "#e535ab",
+    cterm_color = "199",
+    name = "GraphQL"
+  },
   ["gruntfile"] = {
     icon = "",
     color = "#e37933",
@@ -1482,6 +1488,7 @@ local filetypes = {
   ["go"] = "go",
   ["godot"] = "godot",
   ["graphql"] = "graphql",
+  ["gql"] = "gql",
   ["gruntfile"] = "gruntfile",
   ["gulpfile"] = "gulpfile",
   ["haml"] = "haml",


### PR DESCRIPTION
Map `.gql` to same icon as `.graphql` as it is common to use the alternative filetype