### PR TITLE
fix: support ext convention

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1736,7 +1736,7 @@ local function get_default_icon()
 end
 
 local function get_icon(name, ext, opts)
-  ext = ext or name:match("^.*%.(.*)$") or ""
+  ext = ext or name:match("^.-%.(.*%.*.*)$") or ""
   if not loaded then
     setup()
   end
@@ -1759,7 +1759,7 @@ local function get_icon_by_filetype(ft, opts)
 end
 
 local function get_icon_colors(name, ext, opts)
-  ext = ext or name:match("^.*%.(.*)$") or ""
+  ext = ext or name:match("^.-%.(.*%.*.*)$") or ""
   if not loaded then
     setup()
   end


### PR DESCRIPTION
I saw this https://github.com/nvim-tree/nvim-web-devicons/pull/191 and I like the idea of supporting `*.test.js`, `*.stories.tsx`, etc because these are quite common conventions.

The problem is currently this is not working as intended. (Only `test.js` highlights but not `foo.test.js`)

![image](https://user-images.githubusercontent.com/3371732/218235551-f1eb9f34-498b-4c67-9a44-b4b184f3114d.png)

This PR is to fix this issue.
![image](https://user-images.githubusercontent.com/3371732/218235390-d20149a4-3933-438b-a7a2-c9bd8967ade8.png)

*Note*
Whether a plugin can reflect this change depends on the plugin's implementation.
(I see some attempt to support option to switch the way to get icons like this PR: https://github.com/akinsho/bufferline.nvim/pull/669)

![image](https://user-images.githubusercontent.com/3371732/218235973-8d9d2067-cce4-4016-af1e-f05134b66a0e.png)