### PR TITLE
feat: use modern Docker icon

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -153,9 +153,9 @@ local icons_by_filename = {
     name = "GitCommit",
   },
   ["Containerfile"] = {
-    icon = "",
-    color = "#384d54",
-    cterm_color = "59",
+    icon = "󰡨",
+    color = "#458ee6",
+    cterm_color = "33",
     name = "Dockerfile",
   },
   ["COPYING"] = {
@@ -171,9 +171,27 @@ local icons_by_filename = {
     name = "License",
   },
   ["Dockerfile"] = {
-    icon = "",
-    color = "#384d54",
-    cterm_color = "59",
+    icon = "󰡨",
+    color = "#458ee6",
+    cterm_color = "33",
+    name = "Dockerfile",
+  },
+  ["docker-compose.yml"] = {
+    icon = "󰡨",
+    color = "#458ee6",
+    cterm_color = "33",
+    name = "Dockerfile",
+  },
+  ["docker-compose.yaml"] = {
+    icon = "󰡨",
+    color = "#458ee6",
+    cterm_color = "33",
+    name = "Dockerfile",
+  },
+  [".dockerignore"] = {
+    icon = "󰡨",
+    color = "#458ee6",
+    cterm_color = "33",
     name = "Dockerfile",
   },
   ["Gemfile$"] = {
@@ -301,9 +319,9 @@ local icons_by_filename = {
     name = "Procfile",
   },
   ["dockerfile"] = {
-    icon = "",
-    color = "#384d54",
-    cterm_color = "59",
+    icon = "󰡨",
+    color = "#458ee6",
+    cterm_color = "33",
     name = "Dockerfile",
   },
 }


### PR DESCRIPTION
The old Docker icon is nearly invisible in dark background

<img width="160" alt="Screenshot 2023-02-19 at 13 53 09" src="https://user-images.githubusercontent.com/42694704/219933578-4e0cbfcc-70b1-480c-8e46-3b15c041afa4.png">

This PR brings a new modern current Docker icon and adds some related file names also.

<div>
<img width=120 src="https://user-images.githubusercontent.com/42694704/219933717-ec2d12d8-be1a-4a25-b045-9851a4a97b15.png" />

<img width=120 alt="Screenshot 2023-02-19 at 13 58 21" src="https://user-images.githubusercontent.com/42694704/219933759-b1140839-8b6c-4e27-a0fe-a882b11a83fa.png">
</div>

### Preview in editor
<img width="218" alt="Screenshot 2023-02-19 at 13 56 01" src="https://user-images.githubusercontent.com/42694704/219933686-2df84e98-748e-4404-938a-f4623a0c3e6e.png">
