### PR TITLE
feat: add test.ts and spec.ts icon

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1357,6 +1357,18 @@ local icons_by_file_extension = {
     cterm_color = "67",
     name = "Ts",
   },
+  ["test.ts"] = {
+    icon = "",
+    color = "#519aba",
+    cterm_color = "67",
+    name = "TestTs",
+  },
+  ["spec.ts"] = {
+    icon = "",
+    color = "#519aba",
+    cterm_color = "67",
+    name = "SpecTs",
+  },
   ["tscn"] = {
     icon = "",
     color = "#a074c4",


### PR DESCRIPTION
This PR adds an icon similar to the one in VSCode for `test.ts` and `spec.ts` files.

![Screen Shot 2023-02-26 at 22 26 41](https://user-images.githubusercontent.com/26042720/221438259-30c6e860-734c-4687-b440-f1f427246c6a.png)
