### PR TITLE
feat: jsx and tsx icon colors

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1385,7 +1385,7 @@ local icons_by_file_extension = {
     icon = "",
     color = "#8dc149",
     cterm_color = "107",
-    name = "Twig"
+    name = "Twig",
   },
   ["txt"] = {
     icon = "",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -844,8 +844,8 @@ local icons_by_file_extension = {
   },
   ["jsx"] = {
     icon = "",
-    color = "#519aba",
-    cterm_color = "67",
+    color = "#20c2e3",
+    cterm_color = "54",
     name = "Jsx",
   },
   ["ksh"] = {
@@ -1377,15 +1377,15 @@ local icons_by_file_extension = {
   },
   ["tsx"] = {
     icon = "",
-    color = "#519aba",
-    cterm_color = "67",
+    color = "#1354bf",
+    cterm_color = "26",
     name = "Tsx",
   },
   ["twig"] = {
     icon = "",
     color = "#8dc149",
     cterm_color = "107",
-    name = "Twig",
+    name = "Twig"
   },
   ["txt"] = {
     icon = "",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -845,7 +845,7 @@ local icons_by_file_extension = {
   ["jsx"] = {
     icon = "",
     color = "#20c2e3",
-    cterm_color = "54",
+    cterm_color = "45",
     name = "Jsx",
   },
   ["ksh"] = {


### PR DESCRIPTION
Something that really bothered me when I was switching from vs code is no color distinction between .jsx and .tsx icons.
I can imagine frontend developers care about it more than backenders though :)

Before:
![Screenshot 2023-02-28 at 19 59 25](https://user-images.githubusercontent.com/42934159/221966217-2a205fc5-2c43-4a5f-a43d-b8a046aa6538.png)

After:
![Screenshot 2023-02-28 at 19 59 01](https://user-images.githubusercontent.com/42934159/221966243-6dc39e1f-870f-411c-926b-5744afc5cc92.png)

