### PR TITLE
feat: js/ts/jsx/tsx consistent test/spec icons

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -825,10 +825,16 @@ local icons_by_file_extension = {
     name = "Js",
   },
   ["test.js"] = {
-    icon = "",
-    color = "#e37933",
-    cterm_color = "166",
+    icon = "",
+    color = "#cbcb41",
+    cterm_color = "185",
     name = "TestJs",
+  },
+  ["spec.js"] = {
+    icon = "",
+    color = "#cbcb41",
+    cterm_color = "185",
+    name = "SpecJs",
   },
   ["json"] = {
     icon = "",
@@ -847,6 +853,18 @@ local icons_by_file_extension = {
     color = "#519aba",
     cterm_color = "74",
     name = "Jsx",
+  },
+  ["test.jsx"] = {
+    icon = "",
+    color = "#20c2e3",
+    cterm_color = "54",
+    name = "JavaScriptReactTest"
+  },
+  ["spec.jsx"] = {
+    icon = "",
+    color = "#20c2e3",
+    cterm_color = "54",
+    name = "JavaScriptReactSpec"
   },
   ["ksh"] = {
     icon = "",
@@ -1380,6 +1398,18 @@ local icons_by_file_extension = {
     color = "#519aba",
     cterm_color = "74",
     name = "Tsx",
+  },
+  ["test.tsx"] = {
+    icon = "",
+    color = "#1354bf",
+    cterm_color = "26",
+    name = "TypeScriptReactTest",
+  },
+  ["spec.tsx"] = {
+    icon = "",
+    color = "#1354bf",
+    cterm_color = "26",
+    name = "TypeScriptReactSpec",
   },
   ["twig"] = {
     icon = "",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -857,13 +857,13 @@ local icons_by_file_extension = {
   ["test.jsx"] = {
     icon = "",
     color = "#20c2e3",
-    cterm_color = "54",
+    cterm_color = "45",
     name = "JavaScriptReactTest"
   },
   ["spec.jsx"] = {
     icon = "",
     color = "#20c2e3",
-    cterm_color = "54",
+    cterm_color = "45",
     name = "JavaScriptReactSpec"
   },
   ["ksh"] = {


### PR DESCRIPTION
I like that someone has finally added test.ts files, but I think we're missing some consistency now especially for react enthusiasts ;)
So here I come with the setup that I had on my config files (this is what VS Code users would normally get by default).

Before:
![Screenshot 2023-02-28 at 20 16 19](https://user-images.githubusercontent.com/42934159/221970233-ad4e86ea-971a-4bfb-b166-a01caa4d447c.png)

After:
![Screenshot 2023-02-28 at 20 18 48](https://user-images.githubusercontent.com/42934159/221970256-f11152fc-df61-488a-85f6-97aae396e9da.png)

