### PR TITLE
fix: update icon for crystal

### DIFF
--- a/lua/nvim-web-devicons-light.lua
+++ b/lua/nvim-web-devicons-light.lua
@@ -421,7 +421,7 @@ local icons_by_file_extension = {
     name = "Cobol",
   },
   ["cr"] = {
-    icon = "",
+    icon = "",
     color = "#000000",
     cterm_color = "16",
     name = "Crystal",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -454,9 +454,9 @@ local icons_by_file_extension = {
     name = "Cobol",
   },
   ["cr"] = {
-    icon = "",
-    color = "#000000",
-    cterm_color = "16",
+    icon = "",
+    color = "#c8c8c8",
+    cterm_color = "251",
     name = "Crystal",
   },
   ["cs"] = {


### PR DESCRIPTION
There's now a proper icon for Crystal in nerdfont, so we should use that instead. (Refer #68 for the initial icon)

This PR also changes the color in dark theme, as the current one `#000000` is really bad in visibility. The new dark theme color is taken from [vscode-icons](https://github.com/vscode-icons/vscode-icons/wiki/ListOfFiles#crystal).