### PR TITLE
Revert "fix: Update icon for XML"

### DIFF
--- a/lua/nvim-web-devicons-light.lua
+++ b/lua/nvim-web-devicons-light.lua
@@ -1469,7 +1469,7 @@ local icons_by_file_extension = {
     name = "Xlsx",
   },
   ["xml"] = {
-    icon = "",
+    icon = "謹",
     color = "#975122",
     cterm_color = "130",
     name = "Xml",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1502,7 +1502,7 @@ local icons_by_file_extension = {
     name = "Xlsx",
   },
   ["xml"] = {
-    icon = "",
+    icon = "謹",
     color = "#e37933",
     cterm_color = "166",
     name = "Xml",


### PR DESCRIPTION
Reverts nvim-tree/nvim-web-devicons#231

It's because my symbol nerd font was out of date, when I updated it the icon shows up correctly. Although both icons do the job just fine given my PR was based on incorrect assumptions it should be reverted.