### PR TITLE
feat: use official icon for `nim`

### DIFF
--- a/lua/nvim-web-devicons-light.lua
+++ b/lua/nvim-web-devicons-light.lua
@@ -972,7 +972,7 @@ local icons_by_file_extension = {
     name = "Mustache",
   },
   ["nim"] = {
-    icon = "👑",
+    icon = "",
     color = "#514700",
     cterm_color = "58",
     name = "Nim",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -974,7 +974,7 @@ local icons_by_file_extension = {
     name = "Mustache",
   },
   ["nim"] = {
-    icon = "👑",
+    icon = "",
     color = "#f3d400",
     cterm_color = "220",
     name = "Nim",


### PR DESCRIPTION
Nim's offical icon is supported meanwhile. I thought we could use it.

![Screenshot_20230402_192854](https://user-images.githubusercontent.com/34311583/229369363-19b7901e-775e-46d9-b3b5-124df21c5975.png)
![Screenshot_20230402_192935](https://user-images.githubusercontent.com/34311583/229369364-fc3590fa-5e0d-4449-bfb9-1ff3d93b2638.png)
