### PR TITLE
feat: add icon for `V`

### DIFF
--- a/lua/nvim-web-devicons-light.lua
+++ b/lua/nvim-web-devicons-light.lua
@@ -1397,10 +1397,10 @@ local icons_by_file_extension = {
     name = "Txt",
   },
   ["v"] = {
-    icon = "",
-    color = "#017226",
-    cterm_color = "22",
-    name = "Verilog",
+    icon = "𝗩",
+    color = "#5D87BF",
+    cterm_color = "24",
+    name = "V",
   },
   ["vala"] = {
     icon = "",
@@ -1431,6 +1431,12 @@ local icons_by_file_extension = {
     color = "#017226",
     cterm_color = "22",
     name = "Vim",
+  },
+  ["vlang"] = {
+    icon = "𝗩",
+    color = "#5D87BF",
+    cterm_color = "24",
+    name = "V",
   },
   ["vue"] = {
     icon = "﵂",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1399,10 +1399,10 @@ local icons_by_file_extension = {
     name = "Txt",
   },
   ["v"] = {
-    icon = "",
-    color = "#019833",
-    cterm_color = "28",
-    name = "Verilog",
+    icon = "𝗩",
+    color = "#5D87BF",
+    cterm_color = "74",
+    name = "V",
   },
   ["vala"] = {
     icon = "",
@@ -1433,6 +1433,12 @@ local icons_by_file_extension = {
     color = "#019833",
     cterm_color = "28",
     name = "Vim",
+  },
+  ["vlang"] = {
+    icon = "𝗩",
+    color = "#5D87BF",
+    cterm_color = "74",
+    name = "V",
   },
   ["vue"] = {
     icon = "﵂",


### PR DESCRIPTION
This PR adds an icon for the `V` language.

Just `"v"` was updated from currently linking to verilog, since it used by treesitter and lsp for the V language. `"vlang"` was added which is also used by those two, and many other `V` plugins.