### PR TITLE
ci: drop pre-commit from lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,3 +30,4 @@ jobs:
       - name: Light Colorscheme
         run: |
           nvim --headless -c 'set rtp+=./vim-colortemplate' -c 'source scripts/generate_colors.lua' -c 'qall'
+          git diff --exit-code lua/nvim-web-devicons-light.lua

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
           args: --check .
+      - uses: actions/checkout@v3
+        with:
+          repository: lifepillar/vim-colortemplate
+          path: vim-colortemplate
       - name: Light Colorscheme
         run: |
-          nvim --headless -c 'source scripts/generate_colors.lua' -c 'qall'
+          nvim --headless -c 'set rtp+=./vim-colortemplate' -c 'source scripts/generate_colors.lua' -c 'qall'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,13 @@ jobs:
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-      - uses: actions/setup-python@v4.5.0
-      - run: pip install pre-commit
-      - run: pre-commit run --all-files
+      - name: Luacheck
+        run: luacheck --
+      - uses: JohnnyMorganz/stylua-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+          args: --check .
+      - name: Light Colorscheme
+        run: |
+          nvim --headless -c 'source scripts/generate_colors.lua' -c 'qall'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           neovim: true
       - name: Luacheck
-        run: luacheck --
+        run: luacheck lua plugin scripts
       - uses: JohnnyMorganz/stylua-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1,11 +1,5 @@
 -- exact match by file name
 local icons_by_filename = {
-  [".testy"] = {
-    icon = "ﬥ",
-    color = "#cbcb41",
-    cterm_color = "185",
-    name = "Babelrc",
-  },
   [".babelrc"] = {
     icon = "ﬥ",
     color = "#cbcb41",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1,5 +1,11 @@
 -- exact match by file name
 local icons_by_filename = {
+  [".testy"] = {
+    icon = "ﬥ",
+    color = "#cbcb41",
+    cterm_color = "185",
+    name = "Babelrc",
+  },
   [".babelrc"] = {
     icon = "ﬥ",
     color = "#cbcb41",


### PR DESCRIPTION
Use jobs directly instead of through pre-commit.