### PR TITLE
fix: update to Nerd Fonts 3 code points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Notice
+Nerd fonts moved some symbols with version 3.0. Version 2.3 is meant for transition, supporting both version 2 and version 3 icons.
+
+Nvim-web-devicons requires version 2.3 or above to work properly. If you are unable to update please use your plugin manager to pin version of nvim-web-dev icons to `nerd-v2-compat` tag.
+
 # Nvim-web-devicons
 
 A `lua` fork of [vim-devicons](https://github.com/ryanoasis/vim-devicons). This plugin provides the same icons _as well as_ colors for each icon.

--- a/lua/nvim-web-devicons-light.lua
+++ b/lua/nvim-web-devicons-light.lua
@@ -174,7 +174,7 @@ local icons_by_filename = {
     name = "License",
   },
   ["r"] = {
-    icon = "ﳒ",
+    icon = "󰟔",
     color = "#286844",
     cterm_color = "29",
     name = "R",
@@ -262,7 +262,7 @@ local icons_by_filename = {
     name = "Gulpfile",
   },
   ["webpack"] = {
-    icon = "ﰩ",
+    icon = "󰜫",
     color = "#36677c",
     cterm_color = "24",
     name = "Webpack",
@@ -439,7 +439,7 @@ local icons_by_file_extension = {
     name = "Crystal",
   },
   ["cs"] = {
-    icon = "",
+    icon = "󰌛",
     color = "#434d04",
     cterm_color = "58",
     name = "Cs",
@@ -463,7 +463,7 @@ local icons_by_file_extension = {
     name = "Css",
   },
   ["csv"] = {
-    icon = "",
+    icon = "󰈙",
     color = "#447028",
     cterm_color = "22",
     name = "Csv",
@@ -505,13 +505,13 @@ local icons_by_file_extension = {
     name = "Diff",
   },
   ["doc"] = {
-    icon = "",
+    icon = "󰈬",
     color = "#185abd",
     cterm_color = "26",
     name = "Doc",
   },
   ["docx"] = {
-    icon = "",
+    icon = "󰈬",
     color = "#185abd",
     cterm_color = "26",
     name = "Docx",
@@ -924,7 +924,7 @@ local icons_by_file_extension = {
     name = "Markdown",
   },
   ["material"] = {
-    icon = "",
+    icon = "󰔉",
     color = "#8a2b72",
     cterm_color = "89",
     name = "Material",
@@ -942,7 +942,7 @@ local icons_by_file_extension = {
     name = "Mdx",
   },
   ["mint"] = {
-    icon = "",
+    icon = "󰌪",
     color = "#44604a",
     cterm_color = "23",
     name = "Mint",
@@ -990,7 +990,7 @@ local icons_by_file_extension = {
     name = "Nix",
   },
   ["opus"] = {
-    icon = "",
+    icon = "󰈣",
     color = "#a55c01",
     cterm_color = "130",
     name = "OPUS",
@@ -1049,7 +1049,7 @@ local icons_by_file_extension = {
     name = "Pp",
   },
   ["ppt"] = {
-    icon = "",
+    icon = "󰈧",
     color = "#983826",
     cterm_color = "94",
     name = "Ppt",
@@ -1121,7 +1121,7 @@ local icons_by_file_extension = {
     name = "Query",
   },
   ["r"] = {
-    icon = "ﳒ",
+    icon = "󰟔",
     color = "#286844",
     cterm_color = "29",
     name = "R",
@@ -1163,7 +1163,7 @@ local icons_by_file_extension = {
     name = "Rmd",
   },
   ["rproj"] = {
-    icon = "鉶",
+    icon = "󰗆",
     color = "#286844",
     cterm_color = "29",
     name = "Rproj",
@@ -1199,7 +1199,7 @@ local icons_by_file_extension = {
     name = "Scala",
   },
   ["scm"] = {
-    icon = "ﬦ",
+    icon = "󰘧",
     color = "#000000",
     cterm_color = "16",
     name = "Scheme",
@@ -1277,7 +1277,7 @@ local icons_by_file_extension = {
     name = "Suo",
   },
   ["sv"] = {
-    icon = "",
+    icon = "󰍛",
     color = "#017226",
     cterm_color = "22",
     name = "SystemVerilog",
@@ -1289,13 +1289,13 @@ local icons_by_file_extension = {
     name = "Svelte",
   },
   ["svh"] = {
-    icon = "",
+    icon = "󰍛",
     color = "#017226",
     cterm_color = "22",
     name = "SystemVerilog",
   },
   ["svg"] = {
-    icon = "ﰟ",
+    icon = "󰜡",
     color = "#80581e",
     cterm_color = "94",
     name = "Svg",
@@ -1313,13 +1313,13 @@ local icons_by_file_extension = {
     name = "Tor",
   },
   ["tbc"] = {
-    icon = "﯑",
+    icon = "󰛓",
     color = "#1e5cb3",
     cterm_color = "25",
     name = "Tcl",
   },
   ["tcl"] = {
-    icon = "﯑",
+    icon = "󰛓",
     color = "#1e5cb3",
     cterm_color = "25",
     name = "Tcl",
@@ -1331,7 +1331,7 @@ local icons_by_file_extension = {
     name = "Terminal",
   },
   ["tex"] = {
-    icon = "ﭨ",
+    icon = "󰙩",
     color = "#3D6117",
     cterm_color = "22",
     name = "Tex",
@@ -1379,7 +1379,7 @@ local icons_by_file_extension = {
     name = "SpecTs",
   },
   ["tscn"] = {
-    icon = "",
+    icon = "󰎁",
     color = "#6b4d83",
     cterm_color = "96",
     name = "TextScene",
@@ -1409,13 +1409,13 @@ local icons_by_file_extension = {
     name = "Twig",
   },
   ["txt"] = {
-    icon = "",
+    icon = "󰈙",
     color = "#447028",
     cterm_color = "22",
     name = "Txt",
   },
   ["v"] = {
-    icon = "",
+    icon = "󰍛",
     color = "#017226",
     cterm_color = "22",
     name = "Verilog",
@@ -1427,19 +1427,19 @@ local icons_by_file_extension = {
     name = "Vala",
   },
   ["vh"] = {
-    icon = "",
+    icon = "󰍛",
     color = "#017226",
     cterm_color = "22",
     name = "Verilog",
   },
   ["vhd"] = {
-    icon = "",
+    icon = "󰍛",
     color = "#017226",
     cterm_color = "22",
     name = "VHDL",
   },
   ["vhdl"] = {
-    icon = "",
+    icon = "󰍛",
     color = "#017226",
     cterm_color = "22",
     name = "VHDL",
@@ -1469,7 +1469,7 @@ local icons_by_file_extension = {
     name = "Webp",
   },
   ["webpack"] = {
-    icon = "ﰩ",
+    icon = "󰜫",
     color = "#36677c",
     cterm_color = "24",
     name = "Webpack",
@@ -1481,19 +1481,19 @@ local icons_by_file_extension = {
     name = "XcPlayground",
   },
   ["xls"] = {
-    icon = "",
+    icon = "󰈛",
     color = "#207245",
     cterm_color = "29",
     name = "Xls",
   },
   ["xlsx"] = {
-    icon = "",
+    icon = "󰈛",
     color = "#207245",
     cterm_color = "29",
     name = "Xlsx",
   },
   ["xml"] = {
-    icon = "謹",
+    icon = "󰗀",
     color = "#975122",
     cterm_color = "130",
     name = "Xml",
@@ -1529,13 +1529,13 @@ local icons_by_file_extension = {
     name = "Zsh",
   },
   ["sol"] = {
-    icon = "ﲹ",
+    icon = "󰞻",
     color = "#36677c",
     cterm_color = "24",
     name = "Solidity",
   },
   ["prisma"] = {
-    icon = "卑",
+    icon = "󰔶",
     color = "#333333",
     cterm_color = "236",
     name = "Prisma",

--- a/lua/nvim-web-devicons-light.lua
+++ b/lua/nvim-web-devicons-light.lua
@@ -1,6 +1,6 @@
 local icons_by_filename = {
   [".babelrc"] = {
-    icon = "ﬥ",
+    icon = "",
     color = "#666620",
     cterm_color = "58",
     name = "Babelrc",
@@ -822,7 +822,7 @@ local icons_by_file_extension = {
     name = "Json",
   },
   ["json5"] = {
-    icon = "ﬥ",
+    icon = "",
     color = "#666620",
     cterm_color = "58",
     name = "Json5",
@@ -1014,7 +1014,7 @@ local icons_by_file_extension = {
     name = "PackedResource",
   },
   ["pdf"] = {
-    icon = "",
+    icon = "",
     color = "#b30b00",
     cterm_color = "124",
     name = "Pdf",
@@ -1547,7 +1547,7 @@ local icons_by_file_extension = {
     name = "Lock",
   },
   ["log"] = {
-    icon = "",
+    icon = "󰌱",
     color = "#333333",
     cterm_color = "236",
     name = "Log",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1,7 +1,7 @@
 -- exact match by file name
 local icons_by_filename = {
   [".babelrc"] = {
-    icon = "ﬥ",
+    icon = "",
     color = "#cbcb41",
     cterm_color = "185",
     name = "Babelrc",
@@ -824,7 +824,7 @@ local icons_by_file_extension = {
     name = "Json",
   },
   ["json5"] = {
-    icon = "ﬥ",
+    icon = "",
     color = "#cbcb41",
     cterm_color = "185",
     name = "Json5",
@@ -1016,7 +1016,7 @@ local icons_by_file_extension = {
     name = "PackedResource",
   },
   ["pdf"] = {
-    icon = "",
+    icon = "",
     color = "#b30b00",
     cterm_color = "124",
     name = "Pdf",
@@ -1549,7 +1549,7 @@ local icons_by_file_extension = {
     name = "Lock",
   },
   ["log"] = {
-    icon = "",
+    icon = "󰌱",
     color = "#ffffff",
     cterm_color = "231",
     name = "Log",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -175,7 +175,7 @@ local icons_by_filename = {
     name = "License",
   },
   ["r"] = {
-    icon = "ﳒ",
+    icon = "󰟔",
     color = "#358a5b",
     cterm_color = "29",
     name = "R",
@@ -263,7 +263,7 @@ local icons_by_filename = {
     name = "Gulpfile",
   },
   ["webpack"] = {
-    icon = "ﰩ",
+    icon = "󰜫",
     color = "#519aba",
     cterm_color = "74",
     name = "Webpack",
@@ -441,7 +441,7 @@ local icons_by_file_extension = {
     name = "Crystal",
   },
   ["cs"] = {
-    icon = "",
+    icon = "󰌛",
     color = "#596706",
     cterm_color = "58",
     name = "Cs",
@@ -465,7 +465,7 @@ local icons_by_file_extension = {
     name = "Css",
   },
   ["csv"] = {
-    icon = "",
+    icon = "󰈙",
     color = "#89e051",
     cterm_color = "113",
     name = "Csv",
@@ -507,13 +507,13 @@ local icons_by_file_extension = {
     name = "Diff",
   },
   ["doc"] = {
-    icon = "",
+    icon = "󰈬",
     color = "#185abd",
     cterm_color = "26",
     name = "Doc",
   },
   ["docx"] = {
-    icon = "",
+    icon = "󰈬",
     color = "#185abd",
     cterm_color = "26",
     name = "Docx",
@@ -926,7 +926,7 @@ local icons_by_file_extension = {
     name = "Markdown",
   },
   ["material"] = {
-    icon = "",
+    icon = "󰔉",
     color = "#B83998",
     cterm_color = "163",
     name = "Material",
@@ -944,7 +944,7 @@ local icons_by_file_extension = {
     name = "Mdx",
   },
   ["mint"] = {
-    icon = "",
+    icon = "󰌪",
     color = "#87c095",
     cterm_color = "108",
     name = "Mint",
@@ -992,7 +992,7 @@ local icons_by_file_extension = {
     name = "Nix",
   },
   ["opus"] = {
-    icon = "",
+    icon = "󰈣",
     color = "#F88A02",
     cterm_color = "208",
     name = "OPUS",
@@ -1051,7 +1051,7 @@ local icons_by_file_extension = {
     name = "Pp",
   },
   ["ppt"] = {
-    icon = "",
+    icon = "󰈧",
     color = "#cb4a32",
     cterm_color = "214",
     name = "Ppt",
@@ -1123,7 +1123,7 @@ local icons_by_file_extension = {
     name = "Query",
   },
   ["r"] = {
-    icon = "ﳒ",
+    icon = "󰟔",
     color = "#358a5b",
     cterm_color = "29",
     name = "R",
@@ -1165,7 +1165,7 @@ local icons_by_file_extension = {
     name = "Rmd",
   },
   ["rproj"] = {
-    icon = "鉶",
+    icon = "󰗆",
     color = "#358a5b",
     cterm_color = "29",
     name = "Rproj",
@@ -1201,7 +1201,7 @@ local icons_by_file_extension = {
     name = "Scala",
   },
   ["scm"] = {
-    icon = "ﬦ",
+    icon = "󰘧",
     color = "#000000",
     cterm_color = "16",
     name = "Scheme",
@@ -1279,7 +1279,7 @@ local icons_by_file_extension = {
     name = "Suo",
   },
   ["sv"] = {
-    icon = "",
+    icon = "󰍛",
     color = "#019833",
     cterm_color = "28",
     name = "SystemVerilog",
@@ -1291,13 +1291,13 @@ local icons_by_file_extension = {
     name = "Svelte",
   },
   ["svh"] = {
-    icon = "",
+    icon = "󰍛",
     color = "#019833",
     cterm_color = "28",
     name = "SystemVerilog",
   },
   ["svg"] = {
-    icon = "ﰟ",
+    icon = "󰜡",
     color = "#FFB13B",
     cterm_color = "214",
     name = "Svg",
@@ -1315,13 +1315,13 @@ local icons_by_file_extension = {
     name = "Tor",
   },
   ["tbc"] = {
-    icon = "﯑",
+    icon = "󰛓",
     color = "#1e5cb3",
     cterm_color = "25",
     name = "Tcl",
   },
   ["tcl"] = {
-    icon = "﯑",
+    icon = "󰛓",
     color = "#1e5cb3",
     cterm_color = "25",
     name = "Tcl",
@@ -1333,7 +1333,7 @@ local icons_by_file_extension = {
     name = "Terminal",
   },
   ["tex"] = {
-    icon = "ﭨ",
+    icon = "󰙩",
     color = "#3D6117",
     cterm_color = "22",
     name = "Tex",
@@ -1381,7 +1381,7 @@ local icons_by_file_extension = {
     name = "SpecTs",
   },
   ["tscn"] = {
-    icon = "",
+    icon = "󰎁",
     color = "#a074c4",
     cterm_color = "140",
     name = "TextScene",
@@ -1411,13 +1411,13 @@ local icons_by_file_extension = {
     name = "Twig",
   },
   ["txt"] = {
-    icon = "",
+    icon = "󰈙",
     color = "#89e051",
     cterm_color = "113",
     name = "Txt",
   },
   ["v"] = {
-    icon = "",
+    icon = "󰍛",
     color = "#019833",
     cterm_color = "28",
     name = "Verilog",
@@ -1429,19 +1429,19 @@ local icons_by_file_extension = {
     name = "Vala",
   },
   ["vh"] = {
-    icon = "",
+    icon = "󰍛",
     color = "#019833",
     cterm_color = "28",
     name = "Verilog",
   },
   ["vhd"] = {
-    icon = "",
+    icon = "󰍛",
     color = "#019833",
     cterm_color = "28",
     name = "VHDL",
   },
   ["vhdl"] = {
-    icon = "",
+    icon = "󰍛",
     color = "#019833",
     cterm_color = "28",
     name = "VHDL",
@@ -1471,7 +1471,7 @@ local icons_by_file_extension = {
     name = "Webp",
   },
   ["webpack"] = {
-    icon = "ﰩ",
+    icon = "󰜫",
     color = "#519aba",
     cterm_color = "74",
     name = "Webpack",
@@ -1483,19 +1483,19 @@ local icons_by_file_extension = {
     name = "XcPlayground",
   },
   ["xls"] = {
-    icon = "",
+    icon = "󰈛",
     color = "#207245",
     cterm_color = "29",
     name = "Xls",
   },
   ["xlsx"] = {
-    icon = "",
+    icon = "󰈛",
     color = "#207245",
     cterm_color = "29",
     name = "Xlsx",
   },
   ["xml"] = {
-    icon = "謹",
+    icon = "󰗀",
     color = "#e37933",
     cterm_color = "166",
     name = "Xml",
@@ -1531,13 +1531,13 @@ local icons_by_file_extension = {
     name = "Zsh",
   },
   ["sol"] = {
-    icon = "ﲹ",
+    icon = "󰞻",
     color = "#519aba",
     cterm_color = "74",
     name = "Solidity",
   },
   ["prisma"] = {
-    icon = "卑",
+    icon = "󰔶",
     color = "#ffffff",
     cterm_color = "231",
     name = "Prisma",


### PR DESCRIPTION
Nerd Fonts 3 changed code points of some icons, this updates it according  to table [here](https://github.com/ryanoasis/nerd-fonts/issues/1059)

This will break everyone being on Nerd 2, but without it everyone on version 3 is broken also...

fixes #265