### PR TITLE
fix: fixed icon of vue

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1453,7 +1453,7 @@ local icons_by_file_extension = {
     name = "Vim",
   },
   ["vue"] = {
-    icon = "",
+    icon = "﵂",
     color = "#8dc149",
     cterm_color = "113",
     name = "Vue",


### PR DESCRIPTION
Fix reason: I use the font `SauceCodePro Nerd Font Mono `, after i update this plugin to the latest version, the vue icon can not display anymore.