### PR TITLE
fix(#226): allow override hlgroups when background changes

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -2065,7 +2065,7 @@ vim.api.nvim_create_autocmd("OptionSet", {
   callback = function()
     refresh_icons()
     set_up_highlights(true) -- Force update highlights
-  end
+  end,
 })
 
 return {


### PR DESCRIPTION
Fix #226.

Now the icon color variant will change correctly according to current background when user sets the background inside neovim process.

- Before this commit:

    1. On entering nvim: (correct) ![image](https://github.com/nvim-tree/nvim-web-devicons/assets/76579810/416b5281-01e9-4821-b519-d665c43bd351)
    2. After `:set bg=light` light icon for light background   :( ![image](https://github.com/nvim-tree/nvim-web-devicons/assets/76579810/e789feb8-7c31-4a1f-87a0-d66336f23b07)
    3. After `:set bg=dark` dark icon for dark background   :( ![image](https://github.com/nvim-tree/nvim-web-devicons/assets/76579810/38a935c6-6094-4375-8b5d-dca0c502e223)


- After this commit:

    1. On entering nvim ![image](https://github.com/nvim-tree/nvim-web-devicons/assets/76579810/fa6a2a25-5150-4059-9f3e-8b6b2ee635be)
    2. After `:set bg=light`   :) ![image](https://github.com/nvim-tree/nvim-web-devicons/assets/76579810/3ddce976-0f77-4572-839e-922e417b18de)
    3. After: `:set bg=dark`   :) ![image](https://github.com/nvim-tree/nvim-web-devicons/assets/76579810/1bc27c52-c0f3-4922-84c5-60b4d0e0b602)
