### PR TITLE
fix: correct zig icon f0e7->e6a9

### DIFF
--- a/lua/nvim-web-devicons-light.lua
+++ b/lua/nvim-web-devicons-light.lua
@@ -1547,7 +1547,7 @@ local icons_by_file_extension = {
     name = "Yml",
   },
   ["zig"] = {
-    icon = "",
+    icon = "",
     color = "#7b4d0e",
     cterm_color = "94",
     name = "Zig",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1549,7 +1549,7 @@ local icons_by_file_extension = {
     name = "Yml",
   },
   ["zig"] = {
-    icon = "",
+    icon = "",
     color = "#f69a1b",
     cterm_color = "172",
     name = "Zig",


### PR DESCRIPTION
The previous icon was just a thunder. Added correct icon