### PR TITLE
feat: svelte config icon

### DIFF
--- a/lua/nvim-web-devicons-light.lua
+++ b/lua/nvim-web-devicons-light.lua
@@ -83,6 +83,12 @@ local icons_by_filename = {
     cterm_color = "91",
     name = "SettingsJson",
   },
+  ["svelte.config.js"] = {
+    icon = "",
+    color = "#bf2e00",
+    cterm_color = "160",
+    name = "SvelteConfig",
+  },
   [".vimrc"] = {
     icon = "",
     color = "#017226",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -88,7 +88,7 @@ local icons_by_filename = {
     icon = "",
     color = "#ff3e00",
     cterm_color = "196",
-    name = "Svelte",
+    name = "SvelteConfig",
   },
   [".vimrc"] = {
     icon = "",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -84,6 +84,12 @@ local icons_by_filename = {
     cterm_color = "98",
     name = "SettingsJson",
   },
+  ["svelte.config.js"] = {
+    icon = "",
+    color = "#ff3e00",
+    cterm_color = "196",
+    name = "Svelte",
+  },
   [".vimrc"] = {
     icon = "",
     color = "#019833",


### PR DESCRIPTION
This uses the svelte icon for the `svelte.config.js` file.
Many other editors assign specific icons to configs of a framework and I think this should be done here as well.