### PR TITLE
feat: add `.cts` and `.mts` icons

### DIFF
--- a/lua/nvim-web-devicons-light.lua
+++ b/lua/nvim-web-devicons-light.lua
@@ -510,6 +510,12 @@ local icons_by_file_extension = {
     cterm_color = "22",
     name = "Csv",
   },
+  ["cts"] = {
+    icon = "",
+    color = "#36677c",
+    cterm_color = "24",
+    name = "Cts",
+  },
   ["cxx"] = {
     icon = "",
     color = "#36677c",
@@ -1018,6 +1024,12 @@ local icons_by_file_extension = {
     color = "#654ca7",
     cterm_color = "61",
     name = "Motoko",
+  },
+  ["mts"] = {
+    icon = "",
+    color = "#36677c",
+    cterm_color = "24",
+    name = "Mts",
   },
   ["mustache"] = {
     icon = "",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -512,6 +512,12 @@ local icons_by_file_extension = {
     cterm_color = "113",
     name = "Csv",
   },
+  ["cts"] = {
+    icon = "",
+    color = "#519aba",
+    cterm_color = "74",
+    name = "Cts",
+  },
   ["cxx"] = {
     icon = "",
     color = "#519aba",
@@ -1020,6 +1026,12 @@ local icons_by_file_extension = {
     color = "#9772FB",
     cterm_color = "135",
     name = "Motoko",
+  },
+  ["mts"] = {
+    icon = "",
+    color = "#519aba",
+    cterm_color = "74",
+    name = "Mts",
   },
   ["mustache"] = {
     icon = "",


### PR DESCRIPTION
I copied the icon that is used for the `.ts` extension

https://www.typescriptlang.org/docs/handbook/esm-node.html#new-file-extensions