### PR TITLE
fix: add missing icon for R language

### DIFF
--- a/lua/nvim-web-devicons-light.lua
+++ b/lua/nvim-web-devicons-light.lua
@@ -197,6 +197,12 @@ local icons_by_filename = {
     cterm_color = "29",
     name = "R",
   },
+  ["R"] = {
+    icon = "󰟔",
+    color = "#286844",
+    cterm_color = "29",
+    name = "R",
+  },
   ["rmd"] = {
     icon = "",
     color = "#36677c",
@@ -1193,6 +1199,12 @@ local icons_by_file_extension = {
     name = "Query",
   },
   ["r"] = {
+    icon = "󰟔",
+    color = "#286844",
+    cterm_color = "29",
+    name = "R",
+  },
+  ["R"] = {
     icon = "󰟔",
     color = "#286844",
     cterm_color = "29",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -198,6 +198,12 @@ local icons_by_filename = {
     cterm_color = "29",
     name = "R",
   },
+  ["R"] = {
+    icon = "󰟔",
+    color = "#358a5b",
+    cterm_color = "29",
+    name = "R",
+  },
   ["rmd"] = {
     icon = "",
     color = "#519aba",
@@ -1195,6 +1201,12 @@ local icons_by_file_extension = {
     name = "Query",
   },
   ["r"] = {
+    icon = "󰟔",
+    color = "#358a5b",
+    cterm_color = "29",
+    name = "R",
+  },
+  ["R"] = {
     icon = "󰟔",
     color = "#358a5b",
     cterm_color = "29",


### PR DESCRIPTION
Currently, it will only display for `*.r` files. This adds support for `*.R` files. It is common to capitalize `R` for R scripts.

- https://cran.r-project.org/doc/manuals/r-release/R-exts.html