### PR TITLE
feat: Icons for Python type annotation and Cython source

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1243,13 +1243,13 @@ local icons_by_file_extension = {
   ["pxd"] = {
     icon = "",
     color = "#5aa7e4",
-    cterm_color = "74",
+    cterm_color = "39",
     name = "Pxd",
   },
   ["pxi"] = {
     icon = "",
     color = "#5aa7e4",
-    cterm_color = "74",
+    cterm_color = "39",
     name = "Pxi",
   },
   ["py"] = {
@@ -1285,7 +1285,7 @@ local icons_by_file_extension = {
   ["pyx"] = {
     icon = "",
     color = "#5aa7e4",
-    cterm_color = "74",
+    cterm_color = "39",
     name = "Pyx",
   },
   ["query"] = {

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -279,6 +279,12 @@ local icons_by_filename = {
     cterm_color = "197",
     name = "Procfile",
   },
+  ["py.typed"] = {
+    icon = "",
+    color = "#ffbc03",
+    cterm_color = "214",
+    name = "Py.typed",
+  },
   ["r"] = {
     icon = "󰟔",
     color = "#358a5b",
@@ -1234,6 +1240,18 @@ local icons_by_file_extension = {
     cterm_color = "74",
     name = "Psd",
   },
+  ["pxd"] = {
+    icon = "",
+    color = "#5aa7e4",
+    cterm_color = "74",
+    name = "Pxd",
+  },
+  ["pxi"] = {
+    icon = "",
+    color = "#5aa7e4",
+    cterm_color = "74",
+    name = "Pxi",
+  },
   ["py"] = {
     icon = "",
     color = "#ffbc03",
@@ -1252,11 +1270,23 @@ local icons_by_file_extension = {
     cterm_color = "222",
     name = "Pyd",
   },
+  ["pyi"] = {
+    icon = "",
+    color = "#ffbc03",
+    cterm_color = "214",
+    name = "Pyi",
+  },
   ["pyo"] = {
     icon = "",
     color = "#ffe291",
     cterm_color = "222",
     name = "Pyo",
+  },
+  ["pyx"] = {
+    icon = "",
+    color = "#5aa7e4",
+    cterm_color = "74",
+    name = "Pyx",
   },
   ["query"] = {
     icon = "",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1242,13 +1242,13 @@ local icons_by_file_extension = {
   },
   ["pxd"] = {
     icon = "",
-    color = "#306998",
+    color = "#3c6f98",
     cterm_color = "24",
     name = "Pxd",
   },
   ["pxi"] = {
     icon = "",
-    color = "#306998",
+    color = "#3c6f98",
     cterm_color = "24",
     name = "Pxi",
   },
@@ -1284,7 +1284,7 @@ local icons_by_file_extension = {
   },
   ["pyx"] = {
     icon = "",
-    color = "#306998",
+    color = "#3c6f98",
     cterm_color = "24",
     name = "Pyx",
   },

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -279,6 +279,12 @@ local icons_by_filename = {
     cterm_color = "161",
     name = "Procfile",
   },
+  ["py.typed"] = {
+    icon = "",
+    color = "#805e02",
+    cterm_color = "94",
+    name = "Py.typed",
+  },
   ["r"] = {
     icon = "󰟔",
     color = "#286844",
@@ -1234,6 +1240,18 @@ local icons_by_file_extension = {
     cterm_color = "24",
     name = "Psd",
   },
+  ["pxd"] = {
+    icon = "",
+    color = "#306998",
+    cterm_color = "24",
+    name = "Pxd",
+  },
+  ["pxi"] = {
+    icon = "",
+    color = "#306998",
+    cterm_color = "24",
+    name = "Pxi",
+  },
   ["py"] = {
     icon = "",
     color = "#805e02",
@@ -1252,11 +1270,23 @@ local icons_by_file_extension = {
     cterm_color = "236",
     name = "Pyd",
   },
+  ["pyi"] = {
+    icon = "",
+    color = "#805e02",
+    cterm_color = "94",
+    name = "Pyi",
+  },
   ["pyo"] = {
     icon = "",
     color = "#332d1d",
     cterm_color = "236",
     name = "Pyo",
+  },
+  ["pyx"] = {
+    icon = "",
+    color = "#306998",
+    cterm_color = "24",
+    name = "Pyx",
   },
   ["query"] = {
     icon = "",


### PR DESCRIPTION
More python related entries:

- `py.typed` and `.pyi` are [Python type annotation files](https://peps.python.org/pep-0561/#partial-stub-packages)
- `.pyx`, `.pxi` and `.pxd` are [Cython sources](https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#cython-file-types). Cython is considered as different language in vim (`filetype=pyrex`), but still belongs to Python family, so bluish color is used instead of yellow in original Python files.