### PR TITLE
fix: correct solidity icon

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1487,7 +1487,7 @@ local icons_by_file_extension = {
     name = "Sml",
   },
   ["sol"] = {
-    icon = "󰞻",
+    icon = "",
     color = "#519aba",
     cterm_color = "74",
     name = "Solidity",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1487,7 +1487,7 @@ local icons_by_file_extension = {
     name = "Sml",
   },
   ["sol"] = {
-    icon = "󰞻",
+    icon = "",
     color = "#36677c",
     cterm_color = "24",
     name = "Solidity",


### PR DESCRIPTION
(This might be a bit opinionated)

Switch to using Ethereum project icon `nf-seti-ethereum` instead of Ethereum currency icon `nf-md-currency_eth` for solidity files.

Ideally, the solidity icon itself should be used but that is not available in the nerd fonts. But the current currency icon used does not make a lot of sense.

Thanks!