### PR TITLE
ci: generate cterm color even if line is missing

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -278,17 +278,19 @@ local icons_by_filename = {
   ["package.json"] = {
     icon = "",
     color = "#e8274b",
+    cterm_color = "197",
     name = "PackageJson",
   },
   ["package-lock.json"] = {
     icon = "",
     color = "#7a0d21",
+    cterm_color = "52",
     name = "PackageLockJson",
   },
   ["procfile"] = {
     icon = "",
     color = "#a074c4",
-    cterm_color = "197",
+    cterm_color = "140",
     name = "Procfile",
   },
   ["py.typed"] = {
@@ -693,12 +695,13 @@ local icons_by_file_extension = {
   ["epp"] = {
     icon = "",
     color = "#FFA61A",
+    cterm_color = "214",
     name = "Epp",
   },
   ["erb"] = {
     icon = "",
     color = "#701516",
-    cterm_color = "214",
+    cterm_color = "52",
     name = "Erb",
   },
   ["erl"] = {
@@ -738,8 +741,8 @@ local icons_by_file_extension = {
     name = "Flac",
   },
   ["fnl"] = {
-    color = "#fff3d7",
     icon = "🌜",
+    color = "#fff3d7",
     cterm_color = "230",
     name = "Fennel",
   },
@@ -1256,12 +1259,13 @@ local icons_by_file_extension = {
   ["pp"] = {
     icon = "",
     color = "#FFA61A",
+    cterm_color = "214",
     name = "Pp",
   },
   ["ppt"] = {
     icon = "󰈧",
     color = "#cb4a32",
-    cterm_color = "214",
+    cterm_color = "160",
     name = "Ppt",
   },
   ["prisma"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -278,17 +278,19 @@ local icons_by_filename = {
   ["package.json"] = {
     icon = "",
     color = "#ae1d38",
+    cterm_color = "161",
     name = "PackageJson",
   },
   ["package-lock.json"] = {
     icon = "",
     color = "#7a0d21",
+    cterm_color = "52",
     name = "PackageLockJson",
   },
   ["procfile"] = {
     icon = "",
     color = "#6b4d83",
-    cterm_color = "161",
+    cterm_color = "96",
     name = "Procfile",
   },
   ["py.typed"] = {
@@ -693,12 +695,13 @@ local icons_by_file_extension = {
   ["epp"] = {
     icon = "",
     color = "#80530d",
+    cterm_color = "94",
     name = "Epp",
   },
   ["erb"] = {
     icon = "",
     color = "#701516",
-    cterm_color = "94",
+    cterm_color = "52",
     name = "Erb",
   },
   ["erl"] = {
@@ -738,8 +741,8 @@ local icons_by_file_extension = {
     name = "Flac",
   },
   ["fnl"] = {
-    color = "#33312b",
     icon = "🌜",
+    color = "#33312b",
     cterm_color = "236",
     name = "Fennel",
   },
@@ -1256,12 +1259,13 @@ local icons_by_file_extension = {
   ["pp"] = {
     icon = "",
     color = "#80530d",
+    cterm_color = "94",
     name = "Pp",
   },
   ["ppt"] = {
     icon = "󰈧",
     color = "#983826",
-    cterm_color = "94",
+    cterm_color = "124",
     name = "Ppt",
   },
   ["prisma"] = {

--- a/scripts/generate_colors.lua
+++ b/scripts/generate_colors.lua
@@ -22,6 +22,9 @@ if not rc then
   error(err .. "\nPlease ensure lifepillar/vim-colortemplate is present in the runtimepath.")
 end
 
+-- Needed in order to have the correct indentation on line insertion
+vim.o.autoindent = true
+
 --------------------------------------------------------------------------------
 -- Local functions
 --------------------------------------------------------------------------------
@@ -74,17 +77,13 @@ local function update_cterm_colors()
       break
     end
     last = cur
-    local color = fn.getline("."):match "%#......"
-    if fn.search "^\\s*cterm_color" < cur then
-      break
-    end
-    if fn.getline("."):find "%d" then
-      fn.setline(
-        ".",
-        fn.substitute(fn.getline ".", "\\d\\+", function()
-          return tostring(vim.fn["colortemplate#colorspace#approx"](color).index)
-        end, "")
-      )
+    local color = vim.api.nvim_get_current_line():match "%#......"
+    local cterm_color = fn["colortemplate#colorspace#approx"](color).index
+    if fn.search "^\\s*cterm_color" == cur + 1 then
+      vim.cmd(string.format("s/=.*/= %q,", cterm_color))
+    else
+      vim.cmd(tostring(cur))
+      vim.cmd.normal(string.format("octerm_color = %q,", cterm_color))
     end
   end
 end


### PR DESCRIPTION
I noticed that some icons don't have a `cterm_color` value, so I updated the script to generate it if it's missing.