### PR TITLE
ci: harden generation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,11 +23,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
           args: --check .
-      - uses: actions/checkout@v3
-        with:
-          repository: lifepillar/vim-colortemplate
-          path: vim-colortemplate
       - name: Light Colorscheme
         run: |
-          nvim --headless -c 'set rtp+=./vim-colortemplate' -c 'source scripts/generate_colors.lua' -c 'qall'
+          make colors
           git diff --exit-code lua/nvim-web-devicons/icons-light.lua

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .lua
 .luarocks
+vim-colortemplate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ make
 ```
 
 This will:
-1. `git clone https://github.com/lifepillar/vim-colortemplate.git /tmp/vim-colortemplate` if necessary
+1. `git clone --depth 1 https://github.com/lifepillar/vim-colortemplate.git vim-colortemplate` if necessary
 1. Generate cterm colors
 2. Generate light color variants
 3. Check style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,6 @@ Please ensure `icons_by_filename`, `icons_by_file_extension` and `filetypes` are
 
 ## Prerequisites
 
-Add [vim-colortemplate](https://github.com/lifepillar/vim-colortemplate) to &runtimepath. The easiest way to do this is via your package manager.
-
 Code is formatted using stylua and linted using luacheck.
 
 You can install these with:
@@ -41,6 +39,7 @@ make
 ```
 
 This will:
+1. `git clone https://github.com/lifepillar/vim-colortemplate.git /tmp/vim-colortemplate` if necessary
 1. Generate cterm colors
 2. Generate light color variants
 3. Check style

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
 all: colors style-check lint
 
-colors:
-	nvim --headless -c 'source scripts/generate_colors.lua' -c 'qall'
+colors: /tmp/vim-colortemplate
+	nvim \
+		--clean \
+		--headless \
+		--cmd "set rtp^=/tmp/vim-colortemplate" \
+		-c 'source scripts/generate_colors.lua' \
+		-c 'qall'
+
+/tmp/vim-colortemplate:
+	git clone https://github.com/lifepillar/vim-colortemplate.git /tmp/vim-colortemplate
 
 style-check:
 	stylua . --check

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 all: colors style-check lint
 
-colors: /tmp/vim-colortemplate
+colors: vim-colortemplate
 	nvim \
 		--clean \
 		--headless \
-		--cmd "set rtp^=/tmp/vim-colortemplate" \
+		--cmd "set rtp^=vim-colortemplate" \
 		-c 'source scripts/generate_colors.lua' \
 		-c 'qall'
 
-/tmp/vim-colortemplate:
-	git clone https://github.com/lifepillar/vim-colortemplate.git /tmp/vim-colortemplate
+vim-colortemplate:
+	git clone --depth 1 https://github.com/lifepillar/vim-colortemplate.git vim-colortemplate
 
 style-check:
 	stylua . --check

--- a/scripts/generate_colors.lua
+++ b/scripts/generate_colors.lua
@@ -9,17 +9,25 @@
 
 local fn = vim.fn
 
+--- Exit vim
+--- @param msg string
+--- @param rc number
+local function error_exit(msg, rc)
+  print(msg .. "\n")
+  vim.cmd("cq " .. rc)
+end
+
 if not jit then
-  error "Neovim must be LuaJIT-enabled to source this script"
+  error_exit("Neovim must be LuaJIT-enabled to source this script", 1)
 end
 
 if fn.filereadable "lua/nvim-web-devicons.lua" == 0 then
-  error "lua/nvim-web-devicons.lua not found"
+  error_exit("lua/nvim-web-devicons.lua not found", 1)
 end
 
 local rc, err = pcall(vim.fn["colortemplate#colorspace#approx"], "#000000")
 if not rc then
-  error(err .. "\nPlease ensure lifepillar/vim-colortemplate is present in the runtimepath.")
+  error_exit(err .. "\nlifepillar/vim-colortemplate not present in &runtimepath '" .. vim.o.runtimepath .. "'", 1)
 end
 
 -- Needed in order to have the correct indentation on line insertion
@@ -109,7 +117,7 @@ end
 --------------------------------------------------------------------------------
 
 if fn.filereadable "lua/nvim-web-devicons/icons-default.lua" == 0 then
-  error "lua/nvim-web-devicons/icons-default.lua not found!"
+  error_exit("lua/nvim-web-devicons/icons-default.lua not found", 1)
 end
 
 vim.cmd "noswapfile drop lua/nvim-web-devicons/icons-default.lua"
@@ -121,13 +129,13 @@ vim.cmd ":1"
 
 -- first table
 if fn.search("^local icons_by_filename", "c") == 0 then
-  error "Table not found!"
+  error_exit("Table 'icons_by_filename' not found in lua/nvim-web-devicons/icons-default.lua", 1)
 end
 local lines = generate_lines()
 
 -- second table
 if fn.search("^local icons_by_file_extension", "c") == 0 then
-  error "Table not found!"
+  error_exit("Table 'icons_by_file_extension' not found in lua/nvim-web-devicons/icons-default.lua", 1)
 end
 local lines2 = generate_lines()
 table.insert(lines2, "return {")
@@ -157,7 +165,7 @@ print "Finished!"
 --------------------------------------------------------------------------------
 
 if fn.filereadable "lua/nvim-web-devicons/icons-light.lua" == 0 then
-  error "lua/nvim-web-devicons/icons-light.lua not found!"
+  error_exit("lua/nvim-web-devicons/icons-light.lua not found", 1)
 end
 
 vim.cmd "noswapfile drop lua/nvim-web-devicons/icons-light.lua"


### PR DESCRIPTION
Make started failing unpredictably for me. It could be a result of my setup, as we are running the user's full nvim setup.

* Run with `--clean`
* Clone `lifepillar/vim-colortemplate` if needed
* Fail hard
* Simplify CI to use make

Ran out of energy refactoring the ci further...