### PR TITLE
ci: split jobs and pin versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: leafo/gh-actions-lua@v9
-        with:
-          luaVersion: "5.1"
-      - uses: leafo/gh-actions-luarocks@v4
       - name: stylua
         uses: JohnnyMorganz/stylua-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
-          args: --check .
+          args: --check lua scripts
 
   colors:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,16 @@
-name: Lint
-on: pull_request
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - master
+
 permissions:
   contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: install
-        run: |
-          sudo add-apt-repository universe
-          sudo apt install luacheck=1.1 -y
+      - uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "5.1"
+
+      - uses: leafo/gh-actions-luarocks@v4
 
       - name: luacheck
-        run: make lint
+        run: |
+          luarocks install luacheck 1.1.1
+          make lint
 
   style:
     runs-on: ubuntu-latest
@@ -47,5 +50,6 @@ jobs:
           neovim: true
 
       - name: make colors-check
-        run: make colors-check
+        run: |
+          make colors-check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: install
         run: |
           sudo add-apt-repository universe
-          sudo apt install luacheck=1.1 -y
+          sudo apt install lua=5.1 luacheck=1.1 -y
 
       - name: luacheck
         run: make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: install
         run: |
           sudo add-apt-repository universe
-          sudo apt install lua5.1 luacheck=1.1 -y
+          sudo apt install lua=5.1 luacheck=1.1 -y
 
       - name: luacheck
         run: make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: leafo/gh-actions-lua@v9
+        with:
+          luaVersion: "5.1"
       - uses: leafo/gh-actions-luarocks@v4
       - name: luacheck
         run: |
@@ -26,6 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: leafo/gh-actions-lua@v9
+        with:
+          luaVersion: "5.1"
       - uses: leafo/gh-actions-luarocks@v4
       - name: stylua
         uses: JohnnyMorganz/stylua-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: install
         run: |
           sudo add-apt-repository universe
-          sudo apt install lua=5.1 luacheck=1.1 -y
+          sudo apt install lua5.1 luacheck=1.1 -y
 
       - name: luacheck
         run: make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: install
         run: |
           sudo add-apt-repository universe
-          sudo apt install lua=5.1 luacheck=1.1 -y
+          sudo apt install luacheck=1.1 -y
 
       - name: luacheck
         run: make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: install
         run: |
           sudo add-apt-repository universe
-          sudo apt install lua5.1 luacheck -y
+          sudo apt install lua5.1 luacheck=1.1 -y
 
       - name: luacheck
         run: make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,5 @@ jobs:
           neovim: true
 
       - name: make colors-check
-        run: |
-          make colors-check
+        run: make colors-check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,23 +16,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: leafo/gh-actions-lua@v9
-        with:
-          luaVersion: "5.1"
       - uses: leafo/gh-actions-luarocks@v4
-      - name: Install luacheck
-        run: luarocks install luacheck
-      - uses: rhysd/action-setup-vim@v1
-        with:
-          neovim: true
-      - name: Luacheck
-        run: luacheck lua plugin scripts
-      - uses: JohnnyMorganz/stylua-action@v2
+      - name: luacheck
+        run: |
+          luarocks install luacheck
+          make lint
+
+  style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: leafo/gh-actions-luarocks@v4
+      - name: stylua
+        uses: JohnnyMorganz/stylua-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
           args: --check .
-      - name: Light Colorscheme
+
+  colors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+      - name: make colors
         run: |
           make colors
           git diff --exit-code lua/nvim-web-devicons/icons-light.lua
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,33 +16,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: leafo/gh-actions-lua@v9
+
+      - uses: leafo/gh-actions-lua@v10
         with:
           luaVersion: "5.1"
+
       - uses: leafo/gh-actions-luarocks@v4
+
       - name: luacheck
         run: |
-          luarocks install luacheck
+          luarocks install luacheck 1.1.1
           make lint
 
   style:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: stylua
-        uses: JohnnyMorganz/stylua-action@v2
+        uses: JohnnyMorganz/stylua-action@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: latest
+          version: "0.19"
           args: --check lua scripts
 
   colors:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
+
       - name: make colors
         run: |
           make colors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  all:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,14 +20,16 @@ jobs:
         with:
           luaVersion: "5.1"
       - uses: leafo/gh-actions-luarocks@v4
-      - name: Install luacheck
-        run: luarocks install luacheck
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-      - name: Luacheck
-        run: luacheck lua plugin scripts
-      - uses: JohnnyMorganz/stylua-action@v2
+      - name: luacheck
+        uses: leafo/gh-actions-luarocks@v4
+        run: |
+          luarocks install luacheck
+          luacheck lua plugin scripts
+      - name: stylua
+        uses: JohnnyMorganz/stylua-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: leafo/gh-actions-lua@v10
-        with:
-          luaVersion: "5.1"
-
-      - uses: leafo/gh-actions-luarocks@v4
+      - name: install
+        run: |
+          sudo add-apt-repository universe
+          sudo apt install luacheck=1.1 -y
 
       - name: luacheck
-        run: |
-          luarocks install luacheck 1.1.1
-          make lint
+        run: make lint
 
   style:
     runs-on: ubuntu-latest
@@ -50,6 +47,5 @@ jobs:
           neovim: true
 
       - name: make colors-check
-        run: |
-          make colors-check
+        run: make colors-check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,7 @@ jobs:
         with:
           neovim: true
 
-      - name: make colors
+      - name: make colors-check
         run: |
-          make colors
-          git diff --exit-code lua/nvim-web-devicons/icons-light.lua
+          make colors-check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  all:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,16 +20,14 @@ jobs:
         with:
           luaVersion: "5.1"
       - uses: leafo/gh-actions-luarocks@v4
+      - name: Install luacheck
+        run: luarocks install luacheck
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-      - name: luacheck
-        uses: leafo/gh-actions-luarocks@v4
-        run: |
-          luarocks install luacheck
-          luacheck lua plugin scripts
-      - name: stylua
-        uses: JohnnyMorganz/stylua-action@v2
+      - name: Luacheck
+        run: luacheck lua plugin scripts
+      - uses: JohnnyMorganz/stylua-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: install
         run: |
           sudo add-apt-repository universe
-          sudo apt install lua5.1 luacheck=1.1 -y
+          sudo apt install lua5.1 luacheck -y
 
       - name: luacheck
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ colors: vim-colortemplate
 		-c 'source scripts/generate_colors.lua' \
 		-c 'qall'
 
+colors-check: colors
+	git diff --exit-code lua/nvim-web-devicons/icons-light.lua
+
 vim-colortemplate:
 	git clone --depth 1 https://github.com/lifepillar/vim-colortemplate.git vim-colortemplate
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,6 @@ style-fix:
 	stylua .
 
 lint:
-	luacheck .
+	luacheck lua scripts
 
 .PHONY: all colors style-check style-fix lint


### PR DESCRIPTION
Looks more like the nvim-tree CI.

* versions pinned
* uses make targets
* splits into three jobs - yes that starts 3 docker instances however it seems to be best practice
* runs on master