### PR TITLE
ci: pre-commit just calls make

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,20 @@ repos:
     rev: v0.19.1
     hooks:
       - id: stylua-github
+
   - repo: local
     hooks:
       - id: luacheck
         name: Luacheck
         description: Lints Lua files using Luacheck.
-        entry: luacheck --
+        entry: make lint
         language: system
-        types: [lua]
+
   - repo: local
     hooks:
-      - id: lighttheme
-        name: Light Color Scheme Generator
+      - id: colors
+        name: colors
         description: Ensures Light Color Scheme version has been generated.
-        entry: nvim --headless -c 'source scripts/generate_colors.lua' -c 'qall'
+        entry: make colors
         language: system
-        types: [lua]
+


### PR DESCRIPTION
luacheck and colors now use make, which sets things up.

I'll tidy this and `pre-commit-autoupdate.yml` afterwards, for easier review.