### PR TITLE
feat: Update fennel icon to true logo

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -741,7 +741,7 @@ local icons_by_file_extension = {
     name = "Flac",
   },
   ["fnl"] = {
-    icon = "🌜",
+    icon = "",
     color = "#fff3d7",
     cterm_color = "230",
     name = "Fennel",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -741,7 +741,7 @@ local icons_by_file_extension = {
     name = "Flac",
   },
   ["fnl"] = {
-    icon = "🌜",
+    icon = "",
     color = "#33312b",
     cterm_color = "236",
     name = "Fennel",


### PR DESCRIPTION
Update the glyph to the proper logo, added in nerd-fonts#1129 and released as of 3.1.0

Search up the code point [here](https://www.nerdfonts.com/cheat-sheet)