### PR TITLE
feat: luau color change and .luaurc

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -86,7 +86,7 @@ local icons_by_filename = {
   [".luaurc"] = {
     icon = "",
     color = "#00a2ff",
-    cterm_color = "39",
+    cterm_color = "75",
     name = "Luaurc",
   },
   [".npmignore"] = {
@@ -1067,7 +1067,7 @@ local icons_by_file_extension = {
   ["luau"] = {
     icon = "",
     color = "#00a2ff",
-    cterm_color = "39",
+    cterm_color = "75",
     name = "Luau",
   },
   ["m4a"] = {

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -83,6 +83,12 @@ local icons_by_filename = {
     cterm_color = "28",
     name = "Gvimrc",
   },
+  [".luaurc"] = {
+    icon = "",
+    color = "#00a2ff",
+    cterm_color = "39",
+    name = "Luaurc",
+  },
   [".npmignore"] = {
     icon = "",
     color = "#E8274B",
@@ -1060,8 +1066,8 @@ local icons_by_file_extension = {
   },
   ["luau"] = {
     icon = "",
-    color = "#51a0cf",
-    cterm_color = "74",
+    color = "#00a2ff",
+    cterm_color = "39",
     name = "Luau",
   },
   ["m4a"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -85,8 +85,8 @@ local icons_by_filename = {
   },
   [".luaurc"] = {
     icon = "",
-    color = "#005fd7",
-    cterm_color = "26",
+    color = "#007abf",
+    cterm_color = "32",
     name = "Luaurc",
   },
   [".npmignore"] = {
@@ -1066,8 +1066,8 @@ local icons_by_file_extension = {
   },
   ["luau"] = {
     icon = "",
-    color = "#005fd7",
-    cterm_color = "26",
+    color = "#007abf",
+    cterm_color = "32",
     name = "Luau",
   },
   ["m4a"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -83,6 +83,12 @@ local icons_by_filename = {
     cterm_color = "22",
     name = "Gvimrc",
   },
+  [".luaurc"] = {
+    icon = "",
+    color = "#005fd7",
+    cterm_color = "26",
+    name = "Luaurc",
+  },
   [".npmignore"] = {
     icon = "",
     color = "#ae1d38",
@@ -1060,8 +1066,8 @@ local icons_by_file_extension = {
   },
   ["luau"] = {
     icon = "",
-    color = "#366b8a",
-    cterm_color = "24",
+    color = "#005fd7",
+    cterm_color = "26",
     name = "Luau",
   },
   ["m4a"] = {


### PR DESCRIPTION
Nerd fonts still does not have a luau icon, but at least let's keep the original color from the website: https://luau-lang.org/. Luau also supports a `.luaurc` file where you can configure some settings for analysis.