### PR TITLE
ci: download vim colortemplate tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .lua
 .luarocks
-vim-colortemplate
+/vim-colortemplate/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VIM_COLORTEMPLATE_VERSION = 2.2.3
+
 all: colors style-check lint
 
 colors: vim-colortemplate
@@ -12,7 +14,8 @@ colors-check: colors
 	git diff --exit-code lua/nvim-web-devicons/icons-light.lua
 
 vim-colortemplate:
-	git clone --depth 1 https://github.com/lifepillar/vim-colortemplate.git vim-colortemplate
+	mkdir -p vim-colortemplate
+	curl -L https://github.com/lifepillar/vim-colortemplate/archive/refs/tags/v$(VIM_COLORTEMPLATE_VERSION).tar.gz | tar zx --directory vim-colortemplate --strip-components=1
 
 style-check:
 	stylua . --check
@@ -22,5 +25,8 @@ style-fix:
 
 lint:
 	luacheck lua scripts
+
+clean:
+	rm -rf vim-colortemplate
 
 .PHONY: all colors style-check style-fix lint


### PR DESCRIPTION
It seems there was some recycling going on, which resulted in a git clone failure.

https://github.com/nvim-tree/nvim-web-devicons/actions/runs/6999365828