### PR TITLE
ci: remove colors from pre commit

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -11,19 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: leafo/gh-actions-lua@v9
-        with:
-          luaVersion: "5.1"
-      - uses: leafo/gh-actions-luarocks@v4
-      - name: Install luacheck
-        run: luarocks install luacheck
-      - uses: rhysd/action-setup-vim@v1
-        with:
-          neovim: true
       - uses: actions/setup-python@v4.5.0
       - run: pip install pre-commit
       - run: pre-commit autoupdate
-      - run: pre-commit run --all-files
       - uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,3 @@ repos:
         entry: luacheck --
         language: system
         types: [lua]
-  - repo: local
-    hooks:
-      - id: lighttheme
-        name: Light Color Scheme Generator
-        description: Ensures Light Color Scheme version has been generated.
-        entry: nvim --headless -c 'source scripts/generate_colors.lua' -c 'qall'
-        language: system
-        types: [lua]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,20 +3,19 @@ repos:
     rev: v0.19.1
     hooks:
       - id: stylua-github
-
   - repo: local
     hooks:
       - id: luacheck
         name: Luacheck
         description: Lints Lua files using Luacheck.
-        entry: make lint
+        entry: luacheck --
         language: system
-
+        types: [lua]
   - repo: local
     hooks:
-      - id: colors
-        name: colors
+      - id: lighttheme
+        name: Light Color Scheme Generator
         description: Ensures Light Color Scheme version has been generated.
-        entry: make colors
+        entry: nvim --headless -c 'source scripts/generate_colors.lua' -c 'qall'
         language: system
-
+        types: [lua]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,9 @@ repos:
     rev: v0.19.1
     hooks:
       - id: stylua-github
+        fail_fast: true
+        verbose: true
+        types: [lua]
   - repo: local
     hooks:
       - id: luacheck
@@ -10,4 +13,17 @@ repos:
         description: Lints Lua files using Luacheck.
         entry: luacheck --
         language: system
+        fail_fast: true
+        verbose: true
         types: [lua]
+  - repo: local
+    hooks:
+      - id: colors
+        name: colors
+        description: Ensures Light Color Scheme version has been generated.
+        entry: make colors
+        language: system
+        require_serial: true
+        pass_filenames: false
+        verbose: true
+


### PR DESCRIPTION
@gegoune I think I am getting this wrong.

The 'Pre-commit autoupdate' jobs have been passing, until I moved them to the makefile.

The jobs have been failing as `make colors` is called multiple times against all files. That has been reverted.

However it seems that the colors job has never been passing - it's not had vim-colortemplate in the runtimepath. It is marked as successful. This branch is at the last known good commit, with some rubbish in the job. It's passing: https://github.com/nvim-tree/nvim-web-devicons/actions/runs/7000075636

1. Do we need colors in the pre-commit hook or is CI enough?
2. How can we make them work, via make or other means?