### PR TITLE
feat: update `toml` icons

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1659,9 +1659,9 @@ local icons_by_file_extension = {
     name = "TFVars",
   },
   ["toml"] = {
-    icon = "",
-    color = "#6d8086",
-    cterm_color = "66",
+    icon = "",
+    color = "#ffffff",
+    cterm_color = "231",
     name = "Toml",
   },
   ["tres"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1659,9 +1659,9 @@ local icons_by_file_extension = {
     name = "TFVars",
   },
   ["toml"] = {
-    icon = "",
-    color = "#526064",
-    cterm_color = "59",
+    icon = "",
+    color = "#333333",
+    cterm_color = "236",
     name = "Toml",
   },
   ["tres"] = {


### PR DESCRIPTION
Toml icon has been added recently since Nerd Font version `3.1.1`

## Code point:	
<img width="325" alt="Screenshot 2023-12-12 at 23 38 33" src="https://github.com/nvim-tree/nvim-web-devicons/assets/42694704/e1a70e34-17cb-4860-9bd3-04cee040b54c">

## Preview:
<img width="255" alt="Project showcase" src="https://github.com/nvim-tree/nvim-web-devicons/assets/42694704/7d6ea3eb-f35b-4477-b6ce-cae0ec99fe22"/>

## Side note: 
Since the original logo has white background, white color is prefer to the original `#7E7F7F` to make it stand out from others. <img width="25" alt="Toml logo" src="https://github.com/nvim-tree/nvim-web-devicons/assets/42694704/4065bc50-a7a6-45fc-b408-be22bb0174d6">
