### PR TITLE
feat: operating system icons

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 -- When adding new icons, remember to add an entry to the `filetypes` table, if applicable.
-local icons, icons_by_filename, icons_by_file_extension
+local icons, icons_by_filename, icons_by_file_extension, icons_by_operating_system
 
 function M.get_icons()
   return icons
@@ -18,7 +18,8 @@ local function refresh_icons()
 
   icons_by_filename = theme.icons_by_filename
   icons_by_file_extension = theme.icons_by_file_extension
-  icons = vim.tbl_extend("keep", {}, icons_by_filename, icons_by_file_extension)
+  icons_by_operating_system = theme.icons_by_operating_system
+  icons = vim.tbl_extend("keep", {}, icons_by_filename, icons_by_file_extension, icons_by_operating_system)
 end
 
 -- Map of filetypes -> icon names

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1907,6 +1907,394 @@ local icons_by_operating_system = {
     cterm_color = "33",
     name = "Windows"
   },
+  ["linux"] = {
+    icon = "",
+    color = "#000000",
+    cterm_color = "0",
+    name = "Linux"
+  },
+   ["almalinux"] = {
+     icon = "",
+     color = "#000000",
+     cterm_color = "15",
+     name = "Almalinux"
+   },
+   ["alpine"] = {
+     icon = "",
+     color = "#0d597f",
+     cterm_color = "24",
+     name = "Alpine"
+   },
+   ["aosc"] = {
+     icon = "",
+     color = "#000000",
+     cterm_color = "15",
+     name = "AOSC"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["archcraft"] = {
+   --   icon = "",
+   --   color = "#98c47d",
+   --   cterm_color = "108",
+   --   name = "Archcraft"
+   -- },
+   -- Doesn't exist anymore
+   -- ["archlabs"] = {
+   --   icon = "",
+   --   color = "",
+   --   cterm_color = "",
+   --   name = "Archlabs"
+   -- },
+   ["archlinux"] = {
+     icon = "󰣇",
+     color = "#0f94d2",
+     cterm_color = "33",
+     name = "Arch"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["arcolinux"] = {
+   --   icon = "",
+   --   color = "#6790eb",
+   --   cterm_color = "111",
+   --   name = "Arco"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["arduino"] = {
+   --   icon = "",
+   --   color = "#00979C",
+   --   cterm_color = "79",
+   --   name = "Arduino"
+   -- },
+   ["artix"] = {
+     icon = "",
+     color = "#41b4d7",
+     cterm_color = "81",
+     name = "Artix"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["biglinux"] = {
+   --   icon = "",
+   --   color = "#808080",
+   --   cterm_color = "244",
+   --   name = "Biglinux"
+   -- },
+   ["budgie"] = {
+     icon = "",
+     color = "#ffffff",
+     cterm_color = "15",
+     name = "Budgie"
+   },
+   ["centos"] = {
+     icon = "",
+     color = "#a2518d",
+     cterm_color = "127",
+     name = "Centos"
+   },
+   -- -- Discontinued
+   -- ["coreos"] = {
+   --   icon = "",
+   --   color = "#ee0000",
+   --   cterm_color = "9",
+   --   name = "CoreOS"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["crystal"] = {
+   --   icon = "",
+   --   color = "#8839ef",
+   --   cterm_color = "55",
+   --   name = "Crystal"
+   -- },
+   ["debian"] = {
+     icon = "",
+     color = "#a80030",
+     cterm_color = "124",
+     name = "Debian"
+   },
+   ["deepin"] = {
+     icon = "",
+     color = "#2ca7f8",
+     cterm_color = "39",
+     name = "Deepin"
+   },
+   ["devuan"] = {
+     icon = "",
+     color = "#404a52",
+     cterm_color = "59",
+     name = "Devuan"
+   },
+   ["elementary"] = {
+     icon = "",
+     color = "#5890c2",
+     cterm_color = "67",
+     name = "Elementary",
+   },
+   ["endeavour"] = {
+     icon = "",
+     color = "#7b3db9",
+     cterm_color = "55",
+     name = "Endeavour"
+   },
+   ["fedora"] = {
+     icon = "",
+     color = "#072a5e",
+     cterm_color = "18",
+     name = "Fedora"
+   },
+   ["freebsd"] = {
+     icon = "",
+     color = "#c90f02",
+     cterm_color = "160",
+     name = "FreeBSD"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["garuda"] = {
+   --  icon = "",
+   --  color = "#26a9f1",
+   --  cterm_color = "39",
+   --  name = "Garuda"
+   -- },
+   ["gentoo"] = {
+     icon = "󰣨",
+     color = "#b1abce",
+     cterm_color = "146",
+     name = "Gentoo"
+   },
+   ["guix"] = {
+     icon = "",
+     color = "#ffcc00",
+     cterm_color = "220",
+     name = "Guix"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["hyperbola"] = {
+   --   icon = "",
+   --   color = "#d0d0d0",
+   --   cterm_color = "252",
+   --   name = "Hyperbola"
+   -- },
+   ["illumos"] = {
+     icon = "",
+     color = "#ff430f",
+     cterm_color = "9",
+     name = "Illumos"
+   },
+   ["kali_linux"] = {
+     icon = "",
+     color = "#ffffff",
+     cterm_color = "15",
+     name = "Kali"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["kde_neon"] = {
+   --   icon = "",
+   --   color = "#21a1a9",
+   --   cterm_color = "30",
+   --   name = "KDE Neon"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["kubuntu"] = {
+   --   icon = "",
+   --   color = "#0079c1",
+   --   cterm_color = "25",
+   --   name = "Kubuntu"
+   -- },
+   ["mint"] = {
+     icon = "󰣭",
+     color = "#66af3d",
+     cterm_color = "113",
+     name = "Mint"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["locos"] = {
+   --   icon = "",
+   --   color = "#000000",
+   --   cterm_color = "0",
+   --   name = "Locos"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["lxle"] = {
+   --   icon = "",
+   --   color = "#454545",
+   --   cterm_color = "238",
+   --   name = "LXLE"
+   -- },
+   ["mageia"] = {
+     icon = "",
+     color = "#2397d4",
+     cterm_color = "39",
+     name = "Mageia"
+   },
+   -- -- Discontinued
+   -- ["mandriva"] = {
+   --   icon = "",
+   --   color = "",
+   --   cterm_color = "",
+   --   name = "Mandriva"
+   -- },
+   ["manjaro"] = {
+     icon = "",
+     color = "#33b959",
+     cterm_color = "41",
+     name = "Manjaro"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["mate"] = {
+   --   icon = "",
+   --   color = "#93d750",
+   --   cterm_color = "112",
+   --   name = "Mate"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["mxlinux"] = {
+   --   icon = "",
+   --   color = "#ffffff",
+   --   cterm_color = "15",
+   --   name = "MX Linux"
+   -- },
+   -- -- Not an os but we should probably include this somewhere
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["neovim"] = {
+   --   icon = "",
+   --   color = "#6ba63f",
+   --   cterm_color = "71",
+   --   name = "Neovim"
+   -- },
+   ["nixos"] = {
+     icon = "",
+     color = "#7ab1db",
+     cterm_color = "110",
+     name = "NixOS"
+   },
+   ["openbsd"] = {
+     icon = "",
+     color = "#000000",
+     cterm_color = "1",
+     name = "OpenBSD"
+   },
+   ["opensuse"] = {
+     icon = "",
+     color = "#6fb424",
+     cterm_color = "112",
+     name = "openSUSE"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["parabola"] = {
+   --   icon = "",
+   --   color = "#787dab",
+   --   cterm_color = "103",
+   --   name = "Parabola"
+   -- },
+   ["parrot"] = {
+     icon = "",
+     color = "#000000",
+     cterm_color = "1",
+     name = "Parrot"
+   },
+   ["pop_os"] = {
+     icon = "",
+     color = "#48b9c7",
+     cterm_color = "80",
+     name = "Pop!_OS"
+   },
+   -- This icon doesn't show up in my nerdfont patched font...
+   -- ["puppy"] = {
+   --   icon = "",
+   --   color = "#c6c6c6",
+   --   cterm_color = "242",
+   --   name = "Puppy"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["qubesos"] = {
+   --   icon = "",
+   --   color = "#63a1ff",
+   --   cterm_color = "75",
+   --   name = "Qubes OS"
+   -- },
+   ["raspberry_pi"] = {
+     icon = "",
+     color = "#be1848",
+     cterm_color = "124",
+     name = "Raspberry Pi OS"
+   },
+   ["redhat"] = {
+     icon = "󱄛",
+     color = "#EE0000",
+     cterm_color = "196",
+     name = "Redhat"
+   },
+   ["rocky_linux"] = {
+     icon = "",
+     color = "#0fb37d",
+     -- This one is really hard to match, this is the closest I could get
+     cterm_color = "80",
+     name = "Rocky Linux"
+   },
+   ["sabayon"] = {
+     icon = "",
+     color = "#c6c6c6",
+     cterm_color = "242",
+     name = "Sabayon"
+   },
+   ["slackware"] = {
+     icon = "",
+     color = "#475fa9",
+     cterm_color = "67",
+     name = "Slackware"
+   },
+   ["solus"] = {
+     icon = "",
+     color = "#4b5163",
+     cterm_color = "240",
+     name = "Solus"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["tails"] = {
+   --   icon = "",
+   --   color = "#56347c",
+   --   cterm_color = "92",
+   --   name = "Tails"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["trisquel"] = {
+   --   icon = "",
+   --   color = "#487cc2",
+   --   cterm_color = "32",
+   --   name = "Trisquel"
+   -- },
+   ["ubuntu"] = {
+     icon = "",
+     color = "#dd4814",
+     -- This one is really hard to match, this is the closest I could get
+     cterm_color = "166",
+     name = "Ubuntu"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["vanilla"] = {
+   --   icon = "",
+   --   color = "#fbbd4e",
+   --   cterm_color = "179",
+   --   name = "Vanilla"
+   -- },
+   ["void"] = {
+     icon = "",
+     color = "#295340",
+     cterm_color = "22",
+     name = "Void"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font... 
+   -- ["xerolinux"] = {
+   --    icon = "",
+   --    color = "#304381",
+   --    -- This one is really hard to match, this is the closest I could get
+   --    cterm_color = "60",
+   --    name = ""
+   --  },
+   ["zorin"] = {
+     icon = "",
+     color = "#14a1e8",
+     cterm_color = "39",
+     name = "Zorin"
+   },
 }
 
 return {

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1913,7 +1913,7 @@ local icons_by_operating_system = {
     cterm_color = "16",
     name = "Linux",
   },
-  ["almalinux"] = {
+  ["alma"] = {
     icon = "",
     color = "#000000",
     cterm_color = "16",
@@ -1931,7 +1931,7 @@ local icons_by_operating_system = {
     cterm_color = "16",
     name = "AOSC",
   },
-  ["archlinux"] = {
+  ["arch"] = {
     icon = "󰣇",
     color = "#0f94d2",
     cterm_color = "67",
@@ -2015,7 +2015,7 @@ local icons_by_operating_system = {
     cterm_color = "196",
     name = "Illumos",
   },
-  ["kali_linux"] = {
+  ["kali"] = {
     icon = "",
     color = "#ffffff",
     cterm_color = "231",
@@ -2081,7 +2081,7 @@ local icons_by_operating_system = {
     cterm_color = "196",
     name = "Redhat",
   },
-  ["rocky_linux"] = {
+  ["rocky"] = {
     icon = "",
     color = "#0fb37d",
     cterm_color = "36",

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1894,7 +1894,23 @@ local icons_by_file_extension = {
   },
 }
 
+local icons_by_operating_system = {
+  ["apple"] = {
+    icon = "",
+    color = "#A2AAAD",
+    cterm_color = "8",
+    name = "Apple"
+  },
+  ["windows"] = {
+    icon = "",
+    color = "#00A4EF",
+    cterm_color = "33",
+    name = "Windows"
+  },
+}
+
 return {
   icons_by_filename = icons_by_filename,
   icons_by_file_extension = icons_by_file_extension,
+  icons_by_operating_system = icons_by_operating_system
 }

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1938,13 +1938,6 @@ local icons_by_operating_system = {
    --   cterm_color = "108",
    --   name = "Archcraft"
    -- },
-   -- Doesn't exist anymore
-   -- ["archlabs"] = {
-   --   icon = "",
-   --   color = "",
-   --   cterm_color = "",
-   --   name = "Archlabs"
-   -- },
    ["archlinux"] = {
      icon = "󰣇",
      color = "#0f94d2",
@@ -2124,13 +2117,6 @@ local icons_by_operating_system = {
      cterm_color = "39",
      name = "Mageia"
    },
-   -- -- Discontinued
-   -- ["mandriva"] = {
-   --   icon = "",
-   --   color = "",
-   --   cterm_color = "",
-   --   name = "Mandriva"
-   -- },
    ["manjaro"] = {
      icon = "",
      color = "#33b959",

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1898,393 +1898,235 @@ local icons_by_operating_system = {
   ["apple"] = {
     icon = "",
     color = "#A2AAAD",
-    cterm_color = "8",
-    name = "Apple"
+    cterm_color = "248",
+    name = "Apple",
   },
   ["windows"] = {
     icon = "",
     color = "#00A4EF",
-    cterm_color = "33",
-    name = "Windows"
+    cterm_color = "39",
+    name = "Windows",
   },
   ["linux"] = {
     icon = "",
     color = "#000000",
-    cterm_color = "0",
-    name = "Linux"
+    cterm_color = "16",
+    name = "Linux",
   },
-   ["almalinux"] = {
-     icon = "",
-     color = "#000000",
-     cterm_color = "15",
-     name = "Almalinux"
-   },
-   ["alpine"] = {
-     icon = "",
-     color = "#0d597f",
-     cterm_color = "24",
-     name = "Alpine"
-   },
-   ["aosc"] = {
-     icon = "",
-     color = "#000000",
-     cterm_color = "15",
-     name = "AOSC"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["archcraft"] = {
-   --   icon = "",
-   --   color = "#98c47d",
-   --   cterm_color = "108",
-   --   name = "Archcraft"
-   -- },
-   ["archlinux"] = {
-     icon = "󰣇",
-     color = "#0f94d2",
-     cterm_color = "33",
-     name = "Arch"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["arcolinux"] = {
-   --   icon = "",
-   --   color = "#6790eb",
-   --   cterm_color = "111",
-   --   name = "Arco"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["arduino"] = {
-   --   icon = "",
-   --   color = "#00979C",
-   --   cterm_color = "79",
-   --   name = "Arduino"
-   -- },
-   ["artix"] = {
-     icon = "",
-     color = "#41b4d7",
-     cterm_color = "81",
-     name = "Artix"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["biglinux"] = {
-   --   icon = "",
-   --   color = "#808080",
-   --   cterm_color = "244",
-   --   name = "Biglinux"
-   -- },
-   ["budgie"] = {
-     icon = "",
-     color = "#ffffff",
-     cterm_color = "15",
-     name = "Budgie"
-   },
-   ["centos"] = {
-     icon = "",
-     color = "#a2518d",
-     cterm_color = "127",
-     name = "Centos"
-   },
-   -- -- Discontinued
-   -- ["coreos"] = {
-   --   icon = "",
-   --   color = "#ee0000",
-   --   cterm_color = "9",
-   --   name = "CoreOS"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["crystal"] = {
-   --   icon = "",
-   --   color = "#8839ef",
-   --   cterm_color = "55",
-   --   name = "Crystal"
-   -- },
-   ["debian"] = {
-     icon = "",
-     color = "#a80030",
-     cterm_color = "124",
-     name = "Debian"
-   },
-   ["deepin"] = {
-     icon = "",
-     color = "#2ca7f8",
-     cterm_color = "39",
-     name = "Deepin"
-   },
-   ["devuan"] = {
-     icon = "",
-     color = "#404a52",
-     cterm_color = "59",
-     name = "Devuan"
-   },
-   ["elementary"] = {
-     icon = "",
-     color = "#5890c2",
-     cterm_color = "67",
-     name = "Elementary",
-   },
-   ["endeavour"] = {
-     icon = "",
-     color = "#7b3db9",
-     cterm_color = "55",
-     name = "Endeavour"
-   },
-   ["fedora"] = {
-     icon = "",
-     color = "#072a5e",
-     cterm_color = "18",
-     name = "Fedora"
-   },
-   ["freebsd"] = {
-     icon = "",
-     color = "#c90f02",
-     cterm_color = "160",
-     name = "FreeBSD"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["garuda"] = {
-   --  icon = "",
-   --  color = "#26a9f1",
-   --  cterm_color = "39",
-   --  name = "Garuda"
-   -- },
-   ["gentoo"] = {
-     icon = "󰣨",
-     color = "#b1abce",
-     cterm_color = "146",
-     name = "Gentoo"
-   },
-   ["guix"] = {
-     icon = "",
-     color = "#ffcc00",
-     cterm_color = "220",
-     name = "Guix"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["hyperbola"] = {
-   --   icon = "",
-   --   color = "#d0d0d0",
-   --   cterm_color = "252",
-   --   name = "Hyperbola"
-   -- },
-   ["illumos"] = {
-     icon = "",
-     color = "#ff430f",
-     cterm_color = "9",
-     name = "Illumos"
-   },
-   ["kali_linux"] = {
-     icon = "",
-     color = "#ffffff",
-     cterm_color = "15",
-     name = "Kali"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["kde_neon"] = {
-   --   icon = "",
-   --   color = "#21a1a9",
-   --   cterm_color = "30",
-   --   name = "KDE Neon"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["kubuntu"] = {
-   --   icon = "",
-   --   color = "#0079c1",
-   --   cterm_color = "25",
-   --   name = "Kubuntu"
-   -- },
-   ["mint"] = {
-     icon = "󰣭",
-     color = "#66af3d",
-     cterm_color = "113",
-     name = "Mint"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["locos"] = {
-   --   icon = "",
-   --   color = "#000000",
-   --   cterm_color = "0",
-   --   name = "Locos"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["lxle"] = {
-   --   icon = "",
-   --   color = "#454545",
-   --   cterm_color = "238",
-   --   name = "LXLE"
-   -- },
-   ["mageia"] = {
-     icon = "",
-     color = "#2397d4",
-     cterm_color = "39",
-     name = "Mageia"
-   },
-   ["manjaro"] = {
-     icon = "",
-     color = "#33b959",
-     cterm_color = "41",
-     name = "Manjaro"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["mate"] = {
-   --   icon = "",
-   --   color = "#93d750",
-   --   cterm_color = "112",
-   --   name = "Mate"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["mxlinux"] = {
-   --   icon = "",
-   --   color = "#ffffff",
-   --   cterm_color = "15",
-   --   name = "MX Linux"
-   -- },
-   -- -- Not an os but we should probably include this somewhere
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["neovim"] = {
-   --   icon = "",
-   --   color = "#6ba63f",
-   --   cterm_color = "71",
-   --   name = "Neovim"
-   -- },
-   ["nixos"] = {
-     icon = "",
-     color = "#7ab1db",
-     cterm_color = "110",
-     name = "NixOS"
-   },
-   ["openbsd"] = {
-     icon = "",
-     color = "#000000",
-     cterm_color = "1",
-     name = "OpenBSD"
-   },
-   ["opensuse"] = {
-     icon = "",
-     color = "#6fb424",
-     cterm_color = "112",
-     name = "openSUSE"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["parabola"] = {
-   --   icon = "",
-   --   color = "#787dab",
-   --   cterm_color = "103",
-   --   name = "Parabola"
-   -- },
-   ["parrot"] = {
-     icon = "",
-     color = "#000000",
-     cterm_color = "1",
-     name = "Parrot"
-   },
-   ["pop_os"] = {
-     icon = "",
-     color = "#48b9c7",
-     cterm_color = "80",
-     name = "Pop_OS"
-   },
-   -- This icon doesn't show up in my nerdfont patched font...
-   -- ["puppy"] = {
-   --   icon = "",
-   --   color = "#c6c6c6",
-   --   cterm_color = "242",
-   --   name = "Puppy"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["qubesos"] = {
-   --   icon = "",
-   --   color = "#63a1ff",
-   --   cterm_color = "75",
-   --   name = "Qubes OS"
-   -- },
-   ["raspberry_pi"] = {
-     icon = "",
-     color = "#be1848",
-     cterm_color = "124",
-     name = "RaspberryPiOS"
-   },
-   ["redhat"] = {
-     icon = "󱄛",
-     color = "#EE0000",
-     cterm_color = "196",
-     name = "Redhat"
-   },
-   ["rocky_linux"] = {
-     icon = "",
-     color = "#0fb37d",
-     -- This one is really hard to match, this is the closest I could get
-     cterm_color = "80",
-     name = "RockyLinux"
-   },
-   ["sabayon"] = {
-     icon = "",
-     color = "#c6c6c6",
-     cterm_color = "242",
-     name = "Sabayon"
-   },
-   ["slackware"] = {
-     icon = "",
-     color = "#475fa9",
-     cterm_color = "67",
-     name = "Slackware"
-   },
-   ["solus"] = {
-     icon = "",
-     color = "#4b5163",
-     cterm_color = "240",
-     name = "Solus"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["tails"] = {
-   --   icon = "",
-   --   color = "#56347c",
-   --   cterm_color = "92",
-   --   name = "Tails"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["trisquel"] = {
-   --   icon = "",
-   --   color = "#487cc2",
-   --   cterm_color = "32",
-   --   name = "Trisquel"
-   -- },
-   ["ubuntu"] = {
-     icon = "",
-     color = "#dd4814",
-     -- This one is really hard to match, this is the closest I could get
-     cterm_color = "166",
-     name = "Ubuntu"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["vanilla"] = {
-   --   icon = "",
-   --   color = "#fbbd4e",
-   --   cterm_color = "179",
-   --   name = "Vanilla"
-   -- },
-   ["void"] = {
-     icon = "",
-     color = "#295340",
-     cterm_color = "22",
-     name = "Void"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font... 
-   -- ["xerolinux"] = {
-   --    icon = "",
-   --    color = "#304381",
-   --    -- This one is really hard to match, this is the closest I could get
-   --    cterm_color = "60",
-   --    name = ""
-   --  },
-   ["zorin"] = {
-     icon = "",
-     color = "#14a1e8",
-     cterm_color = "39",
-     name = "Zorin"
-   },
+  ["almalinux"] = {
+    icon = "",
+    color = "#000000",
+    cterm_color = "16",
+    name = "Almalinux",
+  },
+  ["alpine"] = {
+    icon = "",
+    color = "#0d597f",
+    cterm_color = "24",
+    name = "Alpine",
+  },
+  ["aosc"] = {
+    icon = "",
+    color = "#000000",
+    cterm_color = "16",
+    name = "AOSC",
+  },
+  ["archlinux"] = {
+    icon = "󰣇",
+    color = "#0f94d2",
+    cterm_color = "67",
+    name = "Arch",
+  },
+  ["artix"] = {
+    icon = "",
+    color = "#41b4d7",
+    cterm_color = "38",
+    name = "Artix",
+  },
+  ["budgie"] = {
+    icon = "",
+    color = "#ffffff",
+    cterm_color = "231",
+    name = "Budgie",
+  },
+  ["centos"] = {
+    icon = "",
+    color = "#a2518d",
+    cterm_color = "132",
+    name = "Centos",
+  },
+  ["debian"] = {
+    icon = "",
+    color = "#a80030",
+    cterm_color = "88",
+    name = "Debian",
+  },
+  ["deepin"] = {
+    icon = "",
+    color = "#2ca7f8",
+    cterm_color = "39",
+    name = "Deepin",
+  },
+  ["devuan"] = {
+    icon = "",
+    color = "#404a52",
+    cterm_color = "238",
+    name = "Devuan",
+  },
+  ["elementary"] = {
+    icon = "",
+    color = "#5890c2",
+    cterm_color = "67",
+    name = "Elementary",
+  },
+  ["endeavour"] = {
+    icon = "",
+    color = "#7b3db9",
+    cterm_color = "91",
+    name = "Endeavour",
+  },
+  ["fedora"] = {
+    icon = "",
+    color = "#072a5e",
+    cterm_color = "17",
+    name = "Fedora",
+  },
+  ["freebsd"] = {
+    icon = "",
+    color = "#c90f02",
+    cterm_color = "160",
+    name = "FreeBSD",
+  },
+  ["gentoo"] = {
+    icon = "󰣨",
+    color = "#b1abce",
+    cterm_color = "146",
+    name = "Gentoo",
+  },
+  ["guix"] = {
+    icon = "",
+    color = "#ffcc00",
+    cterm_color = "220",
+    name = "Guix",
+  },
+  ["illumos"] = {
+    icon = "",
+    color = "#ff430f",
+    cterm_color = "196",
+    name = "Illumos",
+  },
+  ["kali_linux"] = {
+    icon = "",
+    color = "#ffffff",
+    cterm_color = "231",
+    name = "Kali",
+  },
+  ["mint"] = {
+    icon = "󰣭",
+    color = "#66af3d",
+    cterm_color = "70",
+    name = "Mint",
+  },
+  ["mageia"] = {
+    icon = "",
+    color = "#2397d4",
+    cterm_color = "67",
+    name = "Mageia",
+  },
+  ["manjaro"] = {
+    icon = "",
+    color = "#33b959",
+    cterm_color = "35",
+    name = "Manjaro",
+  },
+  ["nixos"] = {
+    icon = "",
+    color = "#7ab1db",
+    cterm_color = "110",
+    name = "NixOS",
+  },
+  ["openbsd"] = {
+    icon = "",
+    color = "#000000",
+    cterm_color = "16",
+    name = "OpenBSD",
+  },
+  ["opensuse"] = {
+    icon = "",
+    color = "#6fb424",
+    cterm_color = "70",
+    name = "openSUSE",
+  },
+  ["parrot"] = {
+    icon = "",
+    color = "#000000",
+    cterm_color = "16",
+    name = "Parrot",
+  },
+  ["pop_os"] = {
+    icon = "",
+    color = "#48b9c7",
+    cterm_color = "73",
+    name = "Pop_OS",
+  },
+  ["raspberry_pi"] = {
+    icon = "",
+    color = "#be1848",
+    cterm_color = "161",
+    name = "RaspberryPiOS",
+  },
+  ["redhat"] = {
+    icon = "󱄛",
+    color = "#EE0000",
+    cterm_color = "196",
+    name = "Redhat",
+  },
+  ["rocky_linux"] = {
+    icon = "",
+    color = "#0fb37d",
+    cterm_color = "36",
+    name = "RockyLinux",
+  },
+  ["sabayon"] = {
+    icon = "",
+    color = "#c6c6c6",
+    cterm_color = "251",
+    name = "Sabayon",
+  },
+  ["slackware"] = {
+    icon = "",
+    color = "#475fa9",
+    cterm_color = "61",
+    name = "Slackware",
+  },
+  ["solus"] = {
+    icon = "",
+    color = "#4b5163",
+    cterm_color = "239",
+    name = "Solus",
+  },
+  ["ubuntu"] = {
+    icon = "",
+    color = "#dd4814",
+    cterm_color = "196",
+    name = "Ubuntu",
+  },
+  ["void"] = {
+    icon = "",
+    color = "#295340",
+    cterm_color = "23",
+    name = "Void",
+  },
+  ["zorin"] = {
+    icon = "",
+    color = "#14a1e8",
+    cterm_color = "39",
+    name = "Zorin",
+  },
 }
 
 return {
   icons_by_filename = icons_by_filename,
   icons_by_file_extension = icons_by_file_extension,
-  icons_by_operating_system = icons_by_operating_system
+  icons_by_operating_system = icons_by_operating_system,
 }

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -2194,7 +2194,7 @@ local icons_by_operating_system = {
      icon = "",
      color = "#48b9c7",
      cterm_color = "80",
-     name = "Pop!_OS"
+     name = "Pop_OS"
    },
    -- This icon doesn't show up in my nerdfont patched font...
    -- ["puppy"] = {
@@ -2214,7 +2214,7 @@ local icons_by_operating_system = {
      icon = "",
      color = "#be1848",
      cterm_color = "124",
-     name = "Raspberry Pi OS"
+     name = "RaspberryPiOS"
    },
    ["redhat"] = {
      icon = "󱄛",
@@ -2227,7 +2227,7 @@ local icons_by_operating_system = {
      color = "#0fb37d",
      -- This one is really hard to match, this is the closest I could get
      cterm_color = "80",
-     name = "Rocky Linux"
+     name = "RockyLinux"
    },
    ["sabayon"] = {
      icon = "",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1907,6 +1907,394 @@ local icons_by_operating_system = {
     cterm_color = "33",
     name = "Windows"
   },
+  ["linux"] = {
+    icon = "",
+    color = "#000000",
+    cterm_color = "0",
+    name = "Linux"
+  },
+   ["almalinux"] = {
+     icon = "",
+     color = "#000000",
+     cterm_color = "15",
+     name = "Almalinux"
+   },
+   ["alpine"] = {
+     icon = "",
+     color = "#0d597f",
+     cterm_color = "24",
+     name = "Alpine"
+   },
+   ["aosc"] = {
+     icon = "",
+     color = "#000000",
+     cterm_color = "15",
+     name = "AOSC"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["archcraft"] = {
+   --   icon = "",
+   --   color = "#98c47d",
+   --   cterm_color = "108",
+   --   name = "Archcraft"
+   -- },
+   -- Doesn't exist anymore
+   -- ["archlabs"] = {
+   --   icon = "",
+   --   color = "",
+   --   cterm_color = "",
+   --   name = "Archlabs"
+   -- },
+   ["archlinux"] = {
+     icon = "󰣇",
+     color = "#0f94d2",
+     cterm_color = "33",
+     name = "Arch"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["arcolinux"] = {
+   --   icon = "",
+   --   color = "#6790eb",
+   --   cterm_color = "111",
+   --   name = "Arco"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["arduino"] = {
+   --   icon = "",
+   --   color = "#00979C",
+   --   cterm_color = "79",
+   --   name = "Arduino"
+   -- },
+   ["artix"] = {
+     icon = "",
+     color = "#41b4d7",
+     cterm_color = "81",
+     name = "Artix"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["biglinux"] = {
+   --   icon = "",
+   --   color = "#808080",
+   --   cterm_color = "244",
+   --   name = "Biglinux"
+   -- },
+   ["budgie"] = {
+     icon = "",
+     color = "#ffffff",
+     cterm_color = "15",
+     name = "Budgie"
+   },
+   ["centos"] = {
+     icon = "",
+     color = "#a2518d",
+     cterm_color = "127",
+     name = "Centos"
+   },
+   -- -- Discontinued
+   -- ["coreos"] = {
+   --   icon = "",
+   --   color = "#ee0000",
+   --   cterm_color = "9",
+   --   name = "CoreOS"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["crystal"] = {
+   --   icon = "",
+   --   color = "#8839ef",
+   --   cterm_color = "55",
+   --   name = "Crystal"
+   -- },
+   ["debian"] = {
+     icon = "",
+     color = "#a80030",
+     cterm_color = "124",
+     name = "Debian"
+   },
+   ["deepin"] = {
+     icon = "",
+     color = "#2ca7f8",
+     cterm_color = "39",
+     name = "Deepin"
+   },
+   ["devuan"] = {
+     icon = "",
+     color = "#404a52",
+     cterm_color = "59",
+     name = "Devuan"
+   },
+   ["elementary"] = {
+     icon = "",
+     color = "#5890c2",
+     cterm_color = "67",
+     name = "Elementary",
+   },
+   ["endeavour"] = {
+     icon = "",
+     color = "#7b3db9",
+     cterm_color = "55",
+     name = "Endeavour"
+   },
+   ["fedora"] = {
+     icon = "",
+     color = "#072a5e",
+     cterm_color = "18",
+     name = "Fedora"
+   },
+   ["freebsd"] = {
+     icon = "",
+     color = "#c90f02",
+     cterm_color = "160",
+     name = "FreeBSD"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["garuda"] = {
+   --  icon = "",
+   --  color = "#26a9f1",
+   --  cterm_color = "39",
+   --  name = "Garuda"
+   -- },
+   ["gentoo"] = {
+     icon = "󰣨",
+     color = "#b1abce",
+     cterm_color = "146",
+     name = "Gentoo"
+   },
+   ["guix"] = {
+     icon = "",
+     color = "#ffcc00",
+     cterm_color = "220",
+     name = "Guix"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["hyperbola"] = {
+   --   icon = "",
+   --   color = "#d0d0d0",
+   --   cterm_color = "252",
+   --   name = "Hyperbola"
+   -- },
+   ["illumos"] = {
+     icon = "",
+     color = "#ff430f",
+     cterm_color = "9",
+     name = "Illumos"
+   },
+   ["kali_linux"] = {
+     icon = "",
+     color = "#ffffff",
+     cterm_color = "15",
+     name = "Kali"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["kde_neon"] = {
+   --   icon = "",
+   --   color = "#21a1a9",
+   --   cterm_color = "30",
+   --   name = "KDE Neon"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["kubuntu"] = {
+   --   icon = "",
+   --   color = "#0079c1",
+   --   cterm_color = "25",
+   --   name = "Kubuntu"
+   -- },
+   ["mint"] = {
+     icon = "󰣭",
+     color = "#66af3d",
+     cterm_color = "113",
+     name = "Mint"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["locos"] = {
+   --   icon = "",
+   --   color = "#000000",
+   --   cterm_color = "0",
+   --   name = "Locos"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["lxle"] = {
+   --   icon = "",
+   --   color = "#454545",
+   --   cterm_color = "238",
+   --   name = "LXLE"
+   -- },
+   ["mageia"] = {
+     icon = "",
+     color = "#2397d4",
+     cterm_color = "39",
+     name = "Mageia"
+   },
+   -- -- Discontinued
+   -- ["mandriva"] = {
+   --   icon = "",
+   --   color = "",
+   --   cterm_color = "",
+   --   name = "Mandriva"
+   -- },
+   ["manjaro"] = {
+     icon = "",
+     color = "#33b959",
+     cterm_color = "41",
+     name = "Manjaro"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["mate"] = {
+   --   icon = "",
+   --   color = "#93d750",
+   --   cterm_color = "112",
+   --   name = "Mate"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["mxlinux"] = {
+   --   icon = "",
+   --   color = "#ffffff",
+   --   cterm_color = "15",
+   --   name = "MX Linux"
+   -- },
+   -- -- Not an os but we should probably include this somewhere
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["neovim"] = {
+   --   icon = "",
+   --   color = "#6ba63f",
+   --   cterm_color = "71",
+   --   name = "Neovim"
+   -- },
+   ["nixos"] = {
+     icon = "",
+     color = "#7ab1db",
+     cterm_color = "110",
+     name = "NixOS"
+   },
+   ["openbsd"] = {
+     icon = "",
+     color = "#000000",
+     cterm_color = "1",
+     name = "OpenBSD"
+   },
+   ["opensuse"] = {
+     icon = "",
+     color = "#6fb424",
+     cterm_color = "112",
+     name = "openSUSE"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["parabola"] = {
+   --   icon = "",
+   --   color = "#787dab",
+   --   cterm_color = "103",
+   --   name = "Parabola"
+   -- },
+   ["parrot"] = {
+     icon = "",
+     color = "#000000",
+     cterm_color = "1",
+     name = "Parrot"
+   },
+   ["pop_os"] = {
+     icon = "",
+     color = "#48b9c7",
+     cterm_color = "80",
+     name = "Pop!_OS"
+   },
+   -- This icon doesn't show up in my nerdfont patched font...
+   -- ["puppy"] = {
+   --   icon = "",
+   --   color = "#c6c6c6",
+   --   cterm_color = "242",
+   --   name = "Puppy"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["qubesos"] = {
+   --   icon = "",
+   --   color = "#63a1ff",
+   --   cterm_color = "75",
+   --   name = "Qubes OS"
+   -- },
+   ["raspberry_pi"] = {
+     icon = "",
+     color = "#be1848",
+     cterm_color = "124",
+     name = "Raspberry Pi OS"
+   },
+   ["redhat"] = {
+     icon = "󱄛",
+     color = "#EE0000",
+     cterm_color = "196",
+     name = "Redhat"
+   },
+   ["rocky_linux"] = {
+     icon = "",
+     color = "#0fb37d",
+     -- This one is really hard to match, this is the closest I could get
+     cterm_color = "80",
+     name = "Rocky Linux"
+   },
+   ["sabayon"] = {
+     icon = "",
+     color = "#c6c6c6",
+     cterm_color = "242",
+     name = "Sabayon"
+   },
+   ["slackware"] = {
+     icon = "",
+     color = "#475fa9",
+     cterm_color = "67",
+     name = "Slackware"
+   },
+   ["solus"] = {
+     icon = "",
+     color = "#4b5163",
+     cterm_color = "240",
+     name = "Solus"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["tails"] = {
+   --   icon = "",
+   --   color = "#56347c",
+   --   cterm_color = "92",
+   --   name = "Tails"
+   -- },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["trisquel"] = {
+   --   icon = "",
+   --   color = "#487cc2",
+   --   cterm_color = "32",
+   --   name = "Trisquel"
+   -- },
+   ["ubuntu"] = {
+     icon = "",
+     color = "#dd4814",
+     -- This one is really hard to match, this is the closest I could get
+     cterm_color = "166",
+     name = "Ubuntu"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font...
+   -- ["vanilla"] = {
+   --   icon = "",
+   --   color = "#fbbd4e",
+   --   cterm_color = "179",
+   --   name = "Vanilla"
+   -- },
+   ["void"] = {
+     icon = "",
+     color = "#295340",
+     cterm_color = "22",
+     name = "Void"
+   },
+   -- -- This icon doesn't show up in my nerdfont patched font... 
+   -- ["xerolinux"] = {
+   --    icon = "",
+   --    color = "#304381",
+   --    -- This one is really hard to match, this is the closest I could get
+   --    cterm_color = "60",
+   --    name = ""
+   --  },
+   ["zorin"] = {
+     icon = "",
+     color = "#14a1e8",
+     cterm_color = "39",
+     name = "Zorin"
+   },
 }
 
 return {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1897,14 +1897,14 @@ local icons_by_file_extension = {
 local icons_by_operating_system = {
   ["apple"] = {
     icon = "",
-    color = "#A2AAAD",
-    cterm_color = "248",
+    color = "#515556",
+    cterm_color = "240",
     name = "Apple",
   },
   ["windows"] = {
     icon = "",
-    color = "#00A4EF",
-    cterm_color = "39",
+    color = "#007bb3",
+    cterm_color = "67",
     name = "Windows",
   },
   ["linux"] = {
@@ -1933,26 +1933,26 @@ local icons_by_operating_system = {
   },
   ["arch"] = {
     icon = "󰣇",
-    color = "#0f94d2",
-    cterm_color = "67",
+    color = "#0b6f9e",
+    cterm_color = "24",
     name = "Arch",
   },
   ["artix"] = {
     icon = "",
-    color = "#41b4d7",
-    cterm_color = "38",
+    color = "#2b788f",
+    cterm_color = "31",
     name = "Artix",
   },
   ["budgie"] = {
     icon = "",
-    color = "#ffffff",
-    cterm_color = "231",
+    color = "#333333",
+    cterm_color = "236",
     name = "Budgie",
   },
   ["centos"] = {
     icon = "",
-    color = "#a2518d",
-    cterm_color = "132",
+    color = "#7a3d6a",
+    cterm_color = "89",
     name = "Centos",
   },
   ["debian"] = {
@@ -1963,8 +1963,8 @@ local icons_by_operating_system = {
   },
   ["deepin"] = {
     icon = "",
-    color = "#2ca7f8",
-    cterm_color = "39",
+    color = "#1d6fa5",
+    cterm_color = "24",
     name = "Deepin",
   },
   ["devuan"] = {
@@ -1975,14 +1975,14 @@ local icons_by_operating_system = {
   },
   ["elementary"] = {
     icon = "",
-    color = "#5890c2",
-    cterm_color = "67",
+    color = "#3b6081",
+    cterm_color = "24",
     name = "Elementary",
   },
   ["endeavour"] = {
     icon = "",
-    color = "#7b3db9",
-    cterm_color = "91",
+    color = "#5c2e8b",
+    cterm_color = "54",
     name = "Endeavour",
   },
   ["fedora"] = {
@@ -1999,50 +1999,50 @@ local icons_by_operating_system = {
   },
   ["gentoo"] = {
     icon = "󰣨",
-    color = "#b1abce",
-    cterm_color = "146",
+    color = "#585667",
+    cterm_color = "60",
     name = "Gentoo",
   },
   ["guix"] = {
     icon = "",
-    color = "#ffcc00",
-    cterm_color = "220",
+    color = "#554400",
+    cterm_color = "58",
     name = "Guix",
   },
   ["illumos"] = {
     icon = "",
-    color = "#ff430f",
-    cterm_color = "196",
+    color = "#bf320b",
+    cterm_color = "160",
     name = "Illumos",
   },
   ["kali"] = {
     icon = "",
-    color = "#ffffff",
-    cterm_color = "231",
+    color = "#333333",
+    cterm_color = "236",
     name = "Kali",
   },
   ["mint"] = {
     icon = "󰣭",
-    color = "#66af3d",
-    cterm_color = "70",
+    color = "#447529",
+    cterm_color = "28",
     name = "Mint",
   },
   ["mageia"] = {
     icon = "",
-    color = "#2397d4",
-    cterm_color = "67",
+    color = "#1a719f",
+    cterm_color = "24",
     name = "Mageia",
   },
   ["manjaro"] = {
     icon = "",
-    color = "#33b959",
-    cterm_color = "35",
+    color = "#227b3b",
+    cterm_color = "29",
     name = "Manjaro",
   },
   ["nixos"] = {
     icon = "",
-    color = "#7ab1db",
-    cterm_color = "110",
+    color = "#3d586e",
+    cterm_color = "24",
     name = "NixOS",
   },
   ["openbsd"] = {
@@ -2053,8 +2053,8 @@ local icons_by_operating_system = {
   },
   ["opensuse"] = {
     icon = "",
-    color = "#6fb424",
-    cterm_color = "70",
+    color = "#4a7818",
+    cterm_color = "64",
     name = "openSUSE",
   },
   ["parrot"] = {
@@ -2065,8 +2065,8 @@ local icons_by_operating_system = {
   },
   ["pop_os"] = {
     icon = "",
-    color = "#48b9c7",
-    cterm_color = "73",
+    color = "#307b85",
+    cterm_color = "30",
     name = "Pop_OS",
   },
   ["raspberry_pi"] = {
@@ -2083,20 +2083,20 @@ local icons_by_operating_system = {
   },
   ["rocky"] = {
     icon = "",
-    color = "#0fb37d",
-    cterm_color = "36",
+    color = "#0b865e",
+    cterm_color = "29",
     name = "RockyLinux",
   },
   ["sabayon"] = {
     icon = "",
-    color = "#c6c6c6",
-    cterm_color = "251",
+    color = "#424242",
+    cterm_color = "238",
     name = "Sabayon",
   },
   ["slackware"] = {
     icon = "",
-    color = "#475fa9",
-    cterm_color = "61",
+    color = "#35477f",
+    cterm_color = "25",
     name = "Slackware",
   },
   ["solus"] = {
@@ -2107,8 +2107,8 @@ local icons_by_operating_system = {
   },
   ["ubuntu"] = {
     icon = "",
-    color = "#dd4814",
-    cterm_color = "196",
+    color = "#a6360f",
+    cterm_color = "124",
     name = "Ubuntu",
   },
   ["void"] = {
@@ -2119,8 +2119,8 @@ local icons_by_operating_system = {
   },
   ["zorin"] = {
     icon = "",
-    color = "#14a1e8",
-    cterm_color = "39",
+    color = "#0f79ae",
+    cterm_color = "67",
     name = "Zorin",
   },
 }
@@ -2128,5 +2128,5 @@ local icons_by_operating_system = {
 return {
   icons_by_filename = icons_by_filename,
   icons_by_file_extension = icons_by_file_extension,
-  icons_by_operating_system = icons_by_operating_system
+  icons_by_operating_system = icons_by_operating_system,
 }

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1898,389 +1898,231 @@ local icons_by_operating_system = {
   ["apple"] = {
     icon = "",
     color = "#A2AAAD",
-    cterm_color = "8",
-    name = "Apple"
+    cterm_color = "248",
+    name = "Apple",
   },
   ["windows"] = {
     icon = "",
     color = "#00A4EF",
-    cterm_color = "33",
-    name = "Windows"
+    cterm_color = "39",
+    name = "Windows",
   },
   ["linux"] = {
     icon = "",
     color = "#000000",
-    cterm_color = "0",
-    name = "Linux"
+    cterm_color = "16",
+    name = "Linux",
   },
-   ["almalinux"] = {
-     icon = "",
-     color = "#000000",
-     cterm_color = "15",
-     name = "Almalinux"
-   },
-   ["alpine"] = {
-     icon = "",
-     color = "#0d597f",
-     cterm_color = "24",
-     name = "Alpine"
-   },
-   ["aosc"] = {
-     icon = "",
-     color = "#000000",
-     cterm_color = "15",
-     name = "AOSC"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["archcraft"] = {
-   --   icon = "",
-   --   color = "#98c47d",
-   --   cterm_color = "108",
-   --   name = "Archcraft"
-   -- },
-   ["archlinux"] = {
-     icon = "󰣇",
-     color = "#0f94d2",
-     cterm_color = "33",
-     name = "Arch"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["arcolinux"] = {
-   --   icon = "",
-   --   color = "#6790eb",
-   --   cterm_color = "111",
-   --   name = "Arco"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["arduino"] = {
-   --   icon = "",
-   --   color = "#00979C",
-   --   cterm_color = "79",
-   --   name = "Arduino"
-   -- },
-   ["artix"] = {
-     icon = "",
-     color = "#41b4d7",
-     cterm_color = "81",
-     name = "Artix"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["biglinux"] = {
-   --   icon = "",
-   --   color = "#808080",
-   --   cterm_color = "244",
-   --   name = "Biglinux"
-   -- },
-   ["budgie"] = {
-     icon = "",
-     color = "#ffffff",
-     cterm_color = "15",
-     name = "Budgie"
-   },
-   ["centos"] = {
-     icon = "",
-     color = "#a2518d",
-     cterm_color = "127",
-     name = "Centos"
-   },
-   -- -- Discontinued
-   -- ["coreos"] = {
-   --   icon = "",
-   --   color = "#ee0000",
-   --   cterm_color = "9",
-   --   name = "CoreOS"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["crystal"] = {
-   --   icon = "",
-   --   color = "#8839ef",
-   --   cterm_color = "55",
-   --   name = "Crystal"
-   -- },
-   ["debian"] = {
-     icon = "",
-     color = "#a80030",
-     cterm_color = "124",
-     name = "Debian"
-   },
-   ["deepin"] = {
-     icon = "",
-     color = "#2ca7f8",
-     cterm_color = "39",
-     name = "Deepin"
-   },
-   ["devuan"] = {
-     icon = "",
-     color = "#404a52",
-     cterm_color = "59",
-     name = "Devuan"
-   },
-   ["elementary"] = {
-     icon = "",
-     color = "#5890c2",
-     cterm_color = "67",
-     name = "Elementary",
-   },
-   ["endeavour"] = {
-     icon = "",
-     color = "#7b3db9",
-     cterm_color = "55",
-     name = "Endeavour"
-   },
-   ["fedora"] = {
-     icon = "",
-     color = "#072a5e",
-     cterm_color = "18",
-     name = "Fedora"
-   },
-   ["freebsd"] = {
-     icon = "",
-     color = "#c90f02",
-     cterm_color = "160",
-     name = "FreeBSD"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["garuda"] = {
-   --  icon = "",
-   --  color = "#26a9f1",
-   --  cterm_color = "39",
-   --  name = "Garuda"
-   -- },
-   ["gentoo"] = {
-     icon = "󰣨",
-     color = "#b1abce",
-     cterm_color = "146",
-     name = "Gentoo"
-   },
-   ["guix"] = {
-     icon = "",
-     color = "#ffcc00",
-     cterm_color = "220",
-     name = "Guix"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["hyperbola"] = {
-   --   icon = "",
-   --   color = "#d0d0d0",
-   --   cterm_color = "252",
-   --   name = "Hyperbola"
-   -- },
-   ["illumos"] = {
-     icon = "",
-     color = "#ff430f",
-     cterm_color = "9",
-     name = "Illumos"
-   },
-   ["kali_linux"] = {
-     icon = "",
-     color = "#ffffff",
-     cterm_color = "15",
-     name = "Kali"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["kde_neon"] = {
-   --   icon = "",
-   --   color = "#21a1a9",
-   --   cterm_color = "30",
-   --   name = "KDE Neon"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["kubuntu"] = {
-   --   icon = "",
-   --   color = "#0079c1",
-   --   cterm_color = "25",
-   --   name = "Kubuntu"
-   -- },
-   ["mint"] = {
-     icon = "󰣭",
-     color = "#66af3d",
-     cterm_color = "113",
-     name = "Mint"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["locos"] = {
-   --   icon = "",
-   --   color = "#000000",
-   --   cterm_color = "0",
-   --   name = "Locos"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["lxle"] = {
-   --   icon = "",
-   --   color = "#454545",
-   --   cterm_color = "238",
-   --   name = "LXLE"
-   -- },
-   ["mageia"] = {
-     icon = "",
-     color = "#2397d4",
-     cterm_color = "39",
-     name = "Mageia"
-   },
-   ["manjaro"] = {
-     icon = "",
-     color = "#33b959",
-     cterm_color = "41",
-     name = "Manjaro"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["mate"] = {
-   --   icon = "",
-   --   color = "#93d750",
-   --   cterm_color = "112",
-   --   name = "Mate"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["mxlinux"] = {
-   --   icon = "",
-   --   color = "#ffffff",
-   --   cterm_color = "15",
-   --   name = "MX Linux"
-   -- },
-   -- -- Not an os but we should probably include this somewhere
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["neovim"] = {
-   --   icon = "",
-   --   color = "#6ba63f",
-   --   cterm_color = "71",
-   --   name = "Neovim"
-   -- },
-   ["nixos"] = {
-     icon = "",
-     color = "#7ab1db",
-     cterm_color = "110",
-     name = "NixOS"
-   },
-   ["openbsd"] = {
-     icon = "",
-     color = "#000000",
-     cterm_color = "1",
-     name = "OpenBSD"
-   },
-   ["opensuse"] = {
-     icon = "",
-     color = "#6fb424",
-     cterm_color = "112",
-     name = "openSUSE"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["parabola"] = {
-   --   icon = "",
-   --   color = "#787dab",
-   --   cterm_color = "103",
-   --   name = "Parabola"
-   -- },
-   ["parrot"] = {
-     icon = "",
-     color = "#000000",
-     cterm_color = "1",
-     name = "Parrot"
-   },
-   ["pop_os"] = {
-     icon = "",
-     color = "#48b9c7",
-     cterm_color = "80",
-     name = "Pop_OS"
-   },
-   -- This icon doesn't show up in my nerdfont patched font...
-   -- ["puppy"] = {
-   --   icon = "",
-   --   color = "#c6c6c6",
-   --   cterm_color = "242",
-   --   name = "Puppy"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["qubesos"] = {
-   --   icon = "",
-   --   color = "#63a1ff",
-   --   cterm_color = "75",
-   --   name = "Qubes OS"
-   -- },
-   ["raspberry_pi"] = {
-     icon = "",
-     color = "#be1848",
-     cterm_color = "124",
-     name = "RaspberryPiOS"
-   },
-   ["redhat"] = {
-     icon = "󱄛",
-     color = "#EE0000",
-     cterm_color = "196",
-     name = "Redhat"
-   },
-   ["rocky_linux"] = {
-     icon = "",
-     color = "#0fb37d",
-     -- This one is really hard to match, this is the closest I could get
-     cterm_color = "80",
-     name = "RockyLinux"
-   },
-   ["sabayon"] = {
-     icon = "",
-     color = "#c6c6c6",
-     cterm_color = "242",
-     name = "Sabayon"
-   },
-   ["slackware"] = {
-     icon = "",
-     color = "#475fa9",
-     cterm_color = "67",
-     name = "Slackware"
-   },
-   ["solus"] = {
-     icon = "",
-     color = "#4b5163",
-     cterm_color = "240",
-     name = "Solus"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["tails"] = {
-   --   icon = "",
-   --   color = "#56347c",
-   --   cterm_color = "92",
-   --   name = "Tails"
-   -- },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["trisquel"] = {
-   --   icon = "",
-   --   color = "#487cc2",
-   --   cterm_color = "32",
-   --   name = "Trisquel"
-   -- },
-   ["ubuntu"] = {
-     icon = "",
-     color = "#dd4814",
-     -- This one is really hard to match, this is the closest I could get
-     cterm_color = "166",
-     name = "Ubuntu"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font...
-   -- ["vanilla"] = {
-   --   icon = "",
-   --   color = "#fbbd4e",
-   --   cterm_color = "179",
-   --   name = "Vanilla"
-   -- },
-   ["void"] = {
-     icon = "",
-     color = "#295340",
-     cterm_color = "22",
-     name = "Void"
-   },
-   -- -- This icon doesn't show up in my nerdfont patched font... 
-   -- ["xerolinux"] = {
-   --    icon = "",
-   --    color = "#304381",
-   --    -- This one is really hard to match, this is the closest I could get
-   --    cterm_color = "60",
-   --    name = ""
-   --  },
-   ["zorin"] = {
-     icon = "",
-     color = "#14a1e8",
-     cterm_color = "39",
-     name = "Zorin"
-   },
+  ["almalinux"] = {
+    icon = "",
+    color = "#000000",
+    cterm_color = "16",
+    name = "Almalinux",
+  },
+  ["alpine"] = {
+    icon = "",
+    color = "#0d597f",
+    cterm_color = "24",
+    name = "Alpine",
+  },
+  ["aosc"] = {
+    icon = "",
+    color = "#000000",
+    cterm_color = "16",
+    name = "AOSC",
+  },
+  ["archlinux"] = {
+    icon = "󰣇",
+    color = "#0f94d2",
+    cterm_color = "67",
+    name = "Arch",
+  },
+  ["artix"] = {
+    icon = "",
+    color = "#41b4d7",
+    cterm_color = "38",
+    name = "Artix",
+  },
+  ["budgie"] = {
+    icon = "",
+    color = "#ffffff",
+    cterm_color = "231",
+    name = "Budgie",
+  },
+  ["centos"] = {
+    icon = "",
+    color = "#a2518d",
+    cterm_color = "132",
+    name = "Centos",
+  },
+  ["debian"] = {
+    icon = "",
+    color = "#a80030",
+    cterm_color = "88",
+    name = "Debian",
+  },
+  ["deepin"] = {
+    icon = "",
+    color = "#2ca7f8",
+    cterm_color = "39",
+    name = "Deepin",
+  },
+  ["devuan"] = {
+    icon = "",
+    color = "#404a52",
+    cterm_color = "238",
+    name = "Devuan",
+  },
+  ["elementary"] = {
+    icon = "",
+    color = "#5890c2",
+    cterm_color = "67",
+    name = "Elementary",
+  },
+  ["endeavour"] = {
+    icon = "",
+    color = "#7b3db9",
+    cterm_color = "91",
+    name = "Endeavour",
+  },
+  ["fedora"] = {
+    icon = "",
+    color = "#072a5e",
+    cterm_color = "17",
+    name = "Fedora",
+  },
+  ["freebsd"] = {
+    icon = "",
+    color = "#c90f02",
+    cterm_color = "160",
+    name = "FreeBSD",
+  },
+  ["gentoo"] = {
+    icon = "󰣨",
+    color = "#b1abce",
+    cterm_color = "146",
+    name = "Gentoo",
+  },
+  ["guix"] = {
+    icon = "",
+    color = "#ffcc00",
+    cterm_color = "220",
+    name = "Guix",
+  },
+  ["illumos"] = {
+    icon = "",
+    color = "#ff430f",
+    cterm_color = "196",
+    name = "Illumos",
+  },
+  ["kali_linux"] = {
+    icon = "",
+    color = "#ffffff",
+    cterm_color = "231",
+    name = "Kali",
+  },
+  ["mint"] = {
+    icon = "󰣭",
+    color = "#66af3d",
+    cterm_color = "70",
+    name = "Mint",
+  },
+  ["mageia"] = {
+    icon = "",
+    color = "#2397d4",
+    cterm_color = "67",
+    name = "Mageia",
+  },
+  ["manjaro"] = {
+    icon = "",
+    color = "#33b959",
+    cterm_color = "35",
+    name = "Manjaro",
+  },
+  ["nixos"] = {
+    icon = "",
+    color = "#7ab1db",
+    cterm_color = "110",
+    name = "NixOS",
+  },
+  ["openbsd"] = {
+    icon = "",
+    color = "#000000",
+    cterm_color = "16",
+    name = "OpenBSD",
+  },
+  ["opensuse"] = {
+    icon = "",
+    color = "#6fb424",
+    cterm_color = "70",
+    name = "openSUSE",
+  },
+  ["parrot"] = {
+    icon = "",
+    color = "#000000",
+    cterm_color = "16",
+    name = "Parrot",
+  },
+  ["pop_os"] = {
+    icon = "",
+    color = "#48b9c7",
+    cterm_color = "73",
+    name = "Pop_OS",
+  },
+  ["raspberry_pi"] = {
+    icon = "",
+    color = "#be1848",
+    cterm_color = "161",
+    name = "RaspberryPiOS",
+  },
+  ["redhat"] = {
+    icon = "󱄛",
+    color = "#EE0000",
+    cterm_color = "196",
+    name = "Redhat",
+  },
+  ["rocky_linux"] = {
+    icon = "",
+    color = "#0fb37d",
+    cterm_color = "36",
+    name = "RockyLinux",
+  },
+  ["sabayon"] = {
+    icon = "",
+    color = "#c6c6c6",
+    cterm_color = "251",
+    name = "Sabayon",
+  },
+  ["slackware"] = {
+    icon = "",
+    color = "#475fa9",
+    cterm_color = "61",
+    name = "Slackware",
+  },
+  ["solus"] = {
+    icon = "",
+    color = "#4b5163",
+    cterm_color = "239",
+    name = "Solus",
+  },
+  ["ubuntu"] = {
+    icon = "",
+    color = "#dd4814",
+    cterm_color = "196",
+    name = "Ubuntu",
+  },
+  ["void"] = {
+    icon = "",
+    color = "#295340",
+    cterm_color = "23",
+    name = "Void",
+  },
+  ["zorin"] = {
+    icon = "",
+    color = "#14a1e8",
+    cterm_color = "39",
+    name = "Zorin",
+  },
 }
 
 return {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1913,7 +1913,7 @@ local icons_by_operating_system = {
     cterm_color = "16",
     name = "Linux",
   },
-  ["almalinux"] = {
+  ["alma"] = {
     icon = "",
     color = "#000000",
     cterm_color = "16",
@@ -1931,7 +1931,7 @@ local icons_by_operating_system = {
     cterm_color = "16",
     name = "AOSC",
   },
-  ["archlinux"] = {
+  ["arch"] = {
     icon = "󰣇",
     color = "#0f94d2",
     cterm_color = "67",
@@ -2015,7 +2015,7 @@ local icons_by_operating_system = {
     cterm_color = "196",
     name = "Illumos",
   },
-  ["kali_linux"] = {
+  ["kali"] = {
     icon = "",
     color = "#ffffff",
     cterm_color = "231",
@@ -2081,7 +2081,7 @@ local icons_by_operating_system = {
     cterm_color = "196",
     name = "Redhat",
   },
-  ["rocky_linux"] = {
+  ["rocky"] = {
     icon = "",
     color = "#0fb37d",
     cterm_color = "36",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1894,7 +1894,23 @@ local icons_by_file_extension = {
   },
 }
 
+local icons_by_operating_system = {
+  ["apple"] = {
+    icon = "",
+    color = "#A2AAAD",
+    cterm_color = "8",
+    name = "Apple"
+  },
+  ["windows"] = {
+    icon = "",
+    color = "#00A4EF",
+    cterm_color = "33",
+    name = "Windows"
+  },
+}
+
 return {
   icons_by_filename = icons_by_filename,
   icons_by_file_extension = icons_by_file_extension,
+  icons_by_operating_system = icons_by_operating_system
 }

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1938,13 +1938,6 @@ local icons_by_operating_system = {
    --   cterm_color = "108",
    --   name = "Archcraft"
    -- },
-   -- Doesn't exist anymore
-   -- ["archlabs"] = {
-   --   icon = "",
-   --   color = "",
-   --   cterm_color = "",
-   --   name = "Archlabs"
-   -- },
    ["archlinux"] = {
      icon = "󰣇",
      color = "#0f94d2",
@@ -2124,13 +2117,6 @@ local icons_by_operating_system = {
      cterm_color = "39",
      name = "Mageia"
    },
-   -- -- Discontinued
-   -- ["mandriva"] = {
-   --   icon = "",
-   --   color = "",
-   --   cterm_color = "",
-   --   name = "Mandriva"
-   -- },
    ["manjaro"] = {
      icon = "",
      color = "#33b959",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -2194,7 +2194,7 @@ local icons_by_operating_system = {
      icon = "",
      color = "#48b9c7",
      cterm_color = "80",
-     name = "Pop!_OS"
+     name = "Pop_OS"
    },
    -- This icon doesn't show up in my nerdfont patched font...
    -- ["puppy"] = {
@@ -2214,7 +2214,7 @@ local icons_by_operating_system = {
      icon = "",
      color = "#be1848",
      cterm_color = "124",
-     name = "Raspberry Pi OS"
+     name = "RaspberryPiOS"
    },
    ["redhat"] = {
      icon = "󱄛",
@@ -2227,7 +2227,7 @@ local icons_by_operating_system = {
      color = "#0fb37d",
      -- This one is really hard to match, this is the closest I could get
      cterm_color = "80",
-     name = "Rocky Linux"
+     name = "RockyLinux"
    },
    ["sabayon"] = {
      icon = "",

--- a/scripts/generate_colors.lua
+++ b/scripts/generate_colors.lua
@@ -140,14 +140,23 @@ if fn.search("^local icons_by_file_extension", "c") == 0 then
   error_exit("Table 'icons_by_file_extension' not found in lua/nvim-web-devicons/icons-default.lua", 1)
 end
 local lines2 = generate_lines()
-table.insert(lines2, "return {")
-table.insert(lines2, "  icons_by_filename = icons_by_filename,")
-table.insert(lines2, "  icons_by_file_extension = icons_by_file_extension,")
-table.insert(lines2, "}")
+
+-- third table
+if fn.search("^local icons_by_operating_system", "c") == 0 then
+  error_exit("Table 'icons_by_operating_system' not found in lua/nvim-web-devicons/icons-default.lua", 1)
+end
+local lines3 = generate_lines()
+
+table.insert(lines3, "return {")
+table.insert(lines3, "  icons_by_filename = icons_by_filename,")
+table.insert(lines3, "  icons_by_file_extension = icons_by_file_extension,")
+table.insert(lines3, "  icons_by_operating_system = icons_by_operating_system,")
+table.insert(lines3, "}")
 
 -- write both tables to file
 fn.writefile(lines, "lua/nvim-web-devicons/icons-light.lua")
 fn.writefile(lines2, "lua/nvim-web-devicons/icons-light.lua", "a")
+fn.writefile(lines3, "lua/nvim-web-devicons/icons-light.lua", "a")
 
 print "Finished creating new file!"
 

--- a/scripts/generate_colors.lua
+++ b/scripts/generate_colors.lua
@@ -139,17 +139,10 @@ local lines = generate_lines()
 if fn.search("^local icons_by_file_extension", "c") == 0 then
   error_exit("Table 'icons_by_file_extension' not found in lua/nvim-web-devicons/icons-default.lua", 1)
 end
-
--- third table
-if fn.search("^local icons_by_operating_system", "c") == 0 then
-  error_exit("Table 'icons_by_operating_system' not found in lua/nvim-web-devicons/icons-default.lua", 1)
-end
-
 local lines2 = generate_lines()
 table.insert(lines2, "return {")
 table.insert(lines2, "  icons_by_filename = icons_by_filename,")
 table.insert(lines2, "  icons_by_file_extension = icons_by_file_extension,")
-table.insert(lines2, "  icons_by_operating_system = icons_by_operating_system,")
 table.insert(lines2, "}")
 
 -- write both tables to file

--- a/scripts/generate_colors.lua
+++ b/scripts/generate_colors.lua
@@ -139,10 +139,17 @@ local lines = generate_lines()
 if fn.search("^local icons_by_file_extension", "c") == 0 then
   error_exit("Table 'icons_by_file_extension' not found in lua/nvim-web-devicons/icons-default.lua", 1)
 end
+
+-- third table
+if fn.search("^local icons_by_operating_system", "c") == 0 then
+  error_exit("Table 'icons_by_operating_system' not found in lua/nvim-web-devicons/icons-default.lua", 1)
+end
+
 local lines2 = generate_lines()
 table.insert(lines2, "return {")
 table.insert(lines2, "  icons_by_filename = icons_by_filename,")
 table.insert(lines2, "  icons_by_file_extension = icons_by_file_extension,")
+table.insert(lines2, "  icons_by_operating_system = icons_by_operating_system,")
 table.insert(lines2, "}")
 
 -- write both tables to file


### PR DESCRIPTION
#361 

There are a few things to call out here.

- This adds a completely new table to the return of `icons-default` and `icons-light` called `icons_by_operating_system`. This set of icons is added with the other icons to the lookup table that is generated during initialization of all devicons.
- This (currently) does not pass the provided make tests due to the addition of the new `icons_by_operating_system` attribute
- There are several icons that I am choosing to omit from this. The following list of icons were omitted as the provided icon by [nerdfonts cheat-sheet](https://www.nerdfonts.com/cheat-sheet) was not found when I pasted it into my terminal. I am currently using the patched version of [firacode](https://github.com/tonsky/FiraCode) so I suspect these various items are all in a newer patch for Firacode. In any case, I did not see them and thus did not want to commit them. I did complete them however so a lua file is attached to this message with each one so that it can be reviewed should someone decide to include these icons
  - archcraft
  - arcolinux
  - arduino
  - biglinux
  - crystal
  - garuda
  - hyperbola
  - kde_neon
  - kubuntu
  - locos
  - lxle
  - mate
  - mxlinux
  - parabola
  - puppy
  - qubesos
  - tails
  - trisquel
  - vanilla
  - xerolinux
  
Pretty much all colors were established via "best guess"/"eyeball test". Others have figured out Apple/Windows color palettes and thus for these 2 I pulled the primary color from their established color palette. Feel free to adjust the color codes as needed. Color can be subjective after all :)

On colors, I did not do anything fancy for any of the OS icons for the 
"light" vs "default". It is a literal copy and paste between the 2. If someone wants different colors for the OS when requesting a "light" version of them, they can do that work lol.

I know that this PR doesn't exactly follow the Contributing guidelines request but given that is a bit chunky and adding stuff that doesn't _really_ have a home, I figured it would be worth explaining that. Do let me know what you believe needs to be changed/fixed/etc to get this in :)

[potential-icons.zip](https://github.com/nvim-tree/nvim-web-devicons/files/13767590/potential-icons.zip)