### PR TITLE
fix: update js icon

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -981,9 +981,9 @@ local icons_by_file_extension = {
     name = "Jpg",
   },
   ["js"] = {
-    icon = "",
-    color = "#cbcb41",
-    cterm_color = "185",
+    icon = "󰌞",
+    color = "#F1F134",
+    cterm_color = "227",
     name = "Js",
   },
   ["json"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -981,8 +981,8 @@ local icons_by_file_extension = {
     name = "Jpg",
   },
   ["js"] = {
-    icon = "",
-    color = "#666620",
+    icon = "󰌞",
+    color = "#505011",
     cterm_color = "58",
     name = "Js",
   },


### PR DESCRIPTION
This updates the icon for JavaScript (js) to the official icon from Nerd Fonts: `f031e`