### PR TITLE
fix: update cjs & mjs icons

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -477,9 +477,9 @@ local icons_by_file_extension = {
     name = "Configuration",
   },
   ["cjs"] = {
-    icon = "",
-    color = "#cbcb41",
-    cterm_color = "185",
+    icon = "󰌞",
+    color = "#F1F134",
+    cterm_color = "227",
     name = "Cjs",
   },
   ["clj"] = {
@@ -1143,9 +1143,9 @@ local icons_by_file_extension = {
     name = "Mint",
   },
   ["mjs"] = {
-    icon = "",
-    color = "#f1e05a",
-    cterm_color = "185",
+    icon = "󰌞",
+    color = "#F1F134",
+    cterm_color = "227",
     name = "Mjs",
   },
   ["mk"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -477,8 +477,8 @@ local icons_by_file_extension = {
     name = "Configuration",
   },
   ["cjs"] = {
-    icon = "",
-    color = "#666620",
+    icon = "󰌞",
+    color = "#505011",
     cterm_color = "58",
     name = "Cjs",
   },
@@ -1143,8 +1143,8 @@ local icons_by_file_extension = {
     name = "Mint",
   },
   ["mjs"] = {
-    icon = "",
-    color = "#504b1e",
+    icon = "󰌞",
+    color = "#505011",
     cterm_color = "58",
     name = "Mjs",
   },


### PR DESCRIPTION
Update **cjs**(CommonJS) & **mjs**(ModuleJS) icons same as **js**(JavaScript) from official Nerd Font icon : `f031e`