### PR TITLE
feat: Add icon for tailwind config

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1726,8 +1726,8 @@ local icons_by_file_extension = {
   },
   ["tsx"] = {
     icon = "",
-    color = "#1354bf",
-    cterm_color = "26",
+    color = "#20c2e3",
+    cterm_color = "45",
     name = "Tsx",
   },
   ["ttf"] = {

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -335,6 +335,12 @@ local icons_by_filename = {
     cterm_color = "196",
     name = "SvelteConfig",
   },
+  ["tailwind.config.js"] = {
+    icon = "󱏿",
+    color = "#20c2e3",
+    cterm_color = "45",
+    name = "TailwindConfig",
+  },
   ["tsconfig.json"] = {
     icon = "",
     color = "#519aba",

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1732,8 +1732,8 @@ local icons_by_file_extension = {
   },
   ["tsx"] = {
     icon = "",
-    color = "#20c2e3",
-    cterm_color = "45",
+    color = "#1354bf",
+    cterm_color = "26",
     name = "Tsx",
   },
   ["ttf"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -335,6 +335,12 @@ local icons_by_filename = {
     cterm_color = "160",
     name = "SvelteConfig",
   },
+  ["tailwind.config.js"] = {
+    icon = "󱏿",
+    color = "#158197",
+    cterm_color = "31",
+    name = "TailwindConfig",
+  },
   ["tsconfig.json"] = {
     icon = "",
     color = "#36677c",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1732,8 +1732,8 @@ local icons_by_file_extension = {
   },
   ["tsx"] = {
     icon = "",
-    color = "#158197",
-    cterm_color = "31",
+    color = "#1354bf",
+    cterm_color = "26",
     name = "Tsx",
   },
   ["ttf"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1726,8 +1726,8 @@ local icons_by_file_extension = {
   },
   ["tsx"] = {
     icon = "",
-    color = "#1354bf",
-    cterm_color = "26",
+    color = "#158197",
+    cterm_color = "31",
     name = "Tsx",
   },
   ["ttf"] = {


### PR DESCRIPTION
## First Commit

Previous `tsx` color was good but that color is a little bit darker. That's why using the same color as `jsx` for `tsx`

**Previous**
![Screenshot_20240107-121141_1](https://github.com/nvim-tree/nvim-web-devicons/assets/118371892/8f8541bb-1de1-466a-9042-9b46fddccba3)

**Updated**
![Screenshot_20240107-121322_1](https://github.com/nvim-tree/nvim-web-devicons/assets/118371892/d9e0275f-8663-4032-9ee1-3e78c6132e7f)

## Second Commit

Add icon for filename  `tailwind.config.js` from official nerd fonts icon `f13ff`