### PR TITLE
fix: update ts, cts, mts and tsconfig.json icon

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -336,7 +336,7 @@ local icons_by_filename = {
     name = "SvelteConfig",
   },
   ["tsconfig.json"] = {
-    icon = "",
+    icon = "",
     color = "#519aba",
     cterm_color = "74",
     name = "TSConfig",
@@ -615,7 +615,7 @@ local icons_by_file_extension = {
     name = "Csv",
   },
   ["cts"] = {
-    icon = "",
+    icon = "󰛦",
     color = "#519aba",
     cterm_color = "74",
     name = "Cts",
@@ -1203,7 +1203,7 @@ local icons_by_file_extension = {
     name = "Mp4",
   },
   ["mts"] = {
-    icon = "",
+    icon = "󰛦",
     color = "#519aba",
     cterm_color = "74",
     name = "Mts",
@@ -1713,7 +1713,7 @@ local icons_by_file_extension = {
     name = "TextResource",
   },
   ["ts"] = {
-    icon = "",
+    icon = "󰛦",
     color = "#519aba",
     cterm_color = "74",
     name = "Ts",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -336,7 +336,7 @@ local icons_by_filename = {
     name = "SvelteConfig",
   },
   ["tsconfig.json"] = {
-    icon = "",
+    icon = "",
     color = "#36677c",
     cterm_color = "24",
     name = "TSConfig",
@@ -615,7 +615,7 @@ local icons_by_file_extension = {
     name = "Csv",
   },
   ["cts"] = {
-    icon = "",
+    icon = "󰛦",
     color = "#36677c",
     cterm_color = "24",
     name = "Cts",
@@ -1203,7 +1203,7 @@ local icons_by_file_extension = {
     name = "Mp4",
   },
   ["mts"] = {
-    icon = "",
+    icon = "󰛦",
     color = "#36677c",
     cterm_color = "24",
     name = "Mts",
@@ -1713,7 +1713,7 @@ local icons_by_file_extension = {
     name = "TextResource",
   },
   ["ts"] = {
-    icon = "",
+    icon = "󰛦",
     color = "#36677c",
     cterm_color = "24",
     name = "Ts",


### PR DESCRIPTION
The original ts and js icons keeps the same style:

![image](https://github.com/nvim-tree/nvim-web-devicons/assets/61115159/cdb9b31b-5be1-4e11-b363-923e346e92c9)

But https://github.com/nvim-tree/nvim-web-devicons/commit/808627b8d412b2a6b6fc6eed816fec3557198b01 and https://github.com/nvim-tree/nvim-web-devicons/commit/33e27b859f549873a826d8aaa348fd31195e439f break this:

![image](https://github.com/nvim-tree/nvim-web-devicons/assets/61115159/3363d272-49d3-4fe6-9887-745551bbf35a)

So I recommend to update the ts icon as well:

![image](https://github.com/nvim-tree/nvim-web-devicons/assets/61115159/3c3f7f6b-c926-4677-943e-4b7b38ffa3c1)

And use the original ts icon for `tsconfig.json`, because they are very similar.

![image](https://github.com/nvim-tree/nvim-web-devicons/assets/61115159/ce7f5aee-9d71-4f12-8632-1003b05c4b36)

**But what I recommend most is to revert these two PRs directly.** There is no reason to do this update, and this also affects the uniform style of other icons, for test.js

![image](https://github.com/nvim-tree/nvim-web-devicons/assets/61115159/d019f609-04eb-4171-b585-d7d809a18619)

This new icon is a completely different style:

![image](https://github.com/nvim-tree/nvim-web-devicons/assets/61115159/9bae460a-6795-46d9-b836-a11748ed3198)

Note: 
I'm not swapping icons for tsconfig and ts, These two icons look the same but they have very subtle differences. These are two icons with different code points. Compare to ts:

e69d(nf-seti-tsconfig):
![image](https://github.com/nvim-tree/nvim-web-devicons/assets/61115159/6797ecff-f1c3-4ac8-a06c-7ee80a013df1)

f06e6(nf-md-language_typescript):
![image](https://github.com/nvim-tree/nvim-web-devicons/assets/61115159/3c3f7f6b-c926-4677-943e-4b7b38ffa3c1)

