### PR TITLE
fix: `get_icons()[1]` being nil after changing &background

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -3,6 +3,13 @@ local M = {}
 -- When adding new icons, remember to add an entry to the `filetypes` table, if applicable.
 local icons, icons_by_filename, icons_by_file_extension, icons_by_operating_system
 
+local default_icon = {
+  icon = "",
+  color = "#6d8086",
+  cterm_color = "66",
+  name = "Default",
+}
+
 function M.get_icons()
   return icons
 end
@@ -28,6 +35,7 @@ local function refresh_icons()
   icons_by_operating_system = theme.icons_by_operating_system
   icons = vim.tbl_extend("keep", {}, icons_by_filename, icons_by_file_extension, icons_by_operating_system)
   icons = vim.tbl_extend("force", icons, global_opts.override)
+  icons[1] = default_icon
 end
 
 -- Map of filetypes -> icon names
@@ -230,13 +238,6 @@ local filetypes = {
   ["zsh"] = "zsh",
 }
 
-local default_icon = {
-  icon = "",
-  color = "#6d8086",
-  cterm_color = "66",
-  name = "Default",
-}
-
 local function get_highlight_name(data)
   if not global_opts.color_icons then
     data = default_icon
@@ -352,7 +353,7 @@ function M.setup(opts)
     icons_by_file_extension = vim.tbl_extend("force", icons_by_file_extension, user_file_ext_icons)
   end
 
-  table.insert(icons, default_icon)
+  icons[1] = default_icon
 
   M.set_up_highlights()
 


### PR DESCRIPTION
The default icon should be in `get_icons()[1]` but it disappears after changing the background. This PR fixes the issue.