### PR TITLE
fix: remove space in zig object notation hl group

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -393,7 +393,7 @@ local icons_by_filename = {
     icon = "",
     color = "#f69a1b",
     cterm_color = "172",
-    name = "Zig Object Notation",
+    name = "ZigObjectNotation",
   },
 }
 

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -393,7 +393,7 @@ local icons_by_filename = {
     icon = "",
     color = "#7b4d0e",
     cterm_color = "94",
-    name = "Zig Object Notation",
+    name = "ZigObjectNotation",
   },
 }
 


### PR DESCRIPTION
Fatal bug, introduced by #395 
Now it works as intended :D

![image](https://github.com/nvim-tree/nvim-web-devicons/assets/2111910/a654907a-4a8e-412a-8702-dceab0de3d7b)


**BUG:**
![image](https://github.com/nvim-tree/nvim-web-devicons/assets/2111910/8105b68e-dbfe-4eaf-8bbc-601e104e173d)
