### PR TITLE
feat: add nu

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -157,6 +157,7 @@ local filetypes = {
   ["mustache"] = "mustache",
   ["nim"] = "nim",
   ["nix"] = "nix",
+  ["nu"] = "nu",
   ["node"] = "node_modules",
   ["ocaml"] = "ml",
   ["ogg"] = "ogg",

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1323,7 +1323,7 @@ local icons_by_file_extension = {
     name = "Nswag",
   },
   ["nu"] = {
-    icon = "",
+    icon = ">",
     color = "#3aa675",
     cterm_color = "36",
     name = "Nushell",

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1322,6 +1322,12 @@ local icons_by_file_extension = {
     cterm_color = "112",
     name = "Nswag",
   },
+  ["nu"] = {
+    icon = "",
+    color = "#3aa675",
+    cterm_color = "36",
+    name = "Nushell",
+  },
   ["ogg"] = {
     icon = "",
     color = "#66D8EF",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1323,7 +1323,7 @@ local icons_by_file_extension = {
     name = "Nswag",
   },
   ["nu"] = {
-    icon = "",
+    icon = ">",
     color = "#276f4e",
     cterm_color = "29",
     name = "Nushell",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1322,6 +1322,12 @@ local icons_by_file_extension = {
     cterm_color = "28",
     name = "Nswag",
   },
+  ["nu"] = {
+    icon = "",
+    color = "#276f4e",
+    cterm_color = "29",
+    name = "Nushell",
+  },
   ["ogg"] = {
     icon = "",
     color = "#336c78",


### PR DESCRIPTION
Icon for Nushell files https://www.nushell.sh/

- Color is Nushell's "Brand" color
- Icon is generic because Nerd Fonts don't include Nushell's chevron-like logo