### PR TITLE
fix: update rust icon

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1569,7 +1569,7 @@ local icons_by_file_extension = {
     name = "Rproj",
   },
   ["rs"] = {
-    icon = "",
+    icon = "",
     color = "#dea584",
     cterm_color = "216",
     name = "Rs",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1569,7 +1569,7 @@ local icons_by_file_extension = {
     name = "Rproj",
   },
   ["rs"] = {
-    icon = "",
+    icon = "",
     color = "#6f5242",
     cterm_color = "95",
     name = "Rs",


### PR DESCRIPTION
Replaces `nf-dev-rust` icon with `nf-md-language_rust` as it renders better on the Kitty terminal.