### PR TITLE
feat: add .prettierrc

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -107,6 +107,12 @@ local icons_by_filename = {
     cterm_color = "197",
     name = "NPMrc",
   },
+  [".prettierrc"] = {
+    icon = "",
+    color = "#4285F4",
+    cterm_color = "33",
+    name = "PrettierConfig",
+  },
   [".settings.json"] = {
     icon = "",
     color = "#854CC7",
@@ -1595,7 +1601,7 @@ local icons_by_file_extension = {
   ["scad"] = {
     icon = "",
     color = "#f9d72c",
-    cterm_color = "226",
+    cterm_color = "220",
     name = "OpenSCAD",
   },
   ["scala"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -107,6 +107,12 @@ local icons_by_filename = {
     cterm_color = "161",
     name = "NPMrc",
   },
+  [".prettierrc"] = {
+    icon = "",
+    color = "#3264b7",
+    cterm_color = "25",
+    name = "PrettierConfig",
+  },
   [".settings.json"] = {
     icon = "",
     color = "#643995",


### PR DESCRIPTION
Icon for Prettier Configuration

File: **.prettierrc**

Issue Resolved: #127 

Icon for Prettier ([This PR](https://github.com/ryanoasis/nerd-fonts/pull/1470#issuecomment-1996766537)) is merged yesterday to the official nerd fonts repo. Website is still not updated also you need to build font from master branch to actually view this icon

Feel free to change color of this icon. I don't have any good colors in my mind to add in this icon.

Here's a Screenshot

![Screenshot_20240315-215324_Termux](https://github.com/nvim-tree/nvim-web-devicons/assets/118371892/03a05540-822f-4d46-9a45-4c7507fe8d0d)
