### PR TITLE
Update tex icon

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1881,7 +1881,7 @@ local icons_by_file_extension = {
     name = "TypeScriptReactTest",
   },
   ["tex"] = {
-    icon = "󰙩",
+    icon = "",
     color = "#3D6117",
     cterm_color = "22",
     name = "Tex",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1881,7 +1881,7 @@ local icons_by_file_extension = {
     name = "TypeScriptReactTest",
   },
   ["tex"] = {
-    icon = "󰙩",
+    icon = "",
     color = "#3D6117",
     cterm_color = "22",
     name = "Tex",


### PR DESCRIPTION
The current TeX icon seems not correct. I think it should be the logo of TeX, not `nf-md-text_shadow`.

󰙩 -> 

Edit: Btw, I have checked the whole codebase before this PR. I confirm there is no other meaning of `tex`. It should have been only mapped to TeX.