### PR TITLE
fix(#435): tex icon

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1881,7 +1881,7 @@ local icons_by_file_extension = {
     name = "TypeScriptReactTest",
   },
   ["tex"] = {
-    icon = "󰙩",
+    icon = "",
     color = "#3D6117",
     cterm_color = "22",
     name = "Tex",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1881,7 +1881,7 @@ local icons_by_file_extension = {
     name = "TypeScriptReactTest",
   },
   ["tex"] = {
-    icon = "󰙩",
+    icon = "",
     color = "#3D6117",
     cterm_color = "22",
     name = "Tex",


### PR DESCRIPTION
Update tex icon from 󰙩 to 
fixes #435