### PR TITLE
feat: add desktop environment and window manager categories with icons

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1,7 +1,8 @@
 local M = {}
 
--- When adding new icons, remember to add an entry to the `filetypes` table, if applicable.
+-- NOTE: When adding new icons, remember to add an entry to the `filetypes` table, if applicable.
 local icons, icons_by_filename, icons_by_file_extension, icons_by_operating_system
+local icons_by_desktop_environment, icons_by_window_manager
 
 local default_icon = {
   icon = "",
@@ -33,7 +34,17 @@ local function refresh_icons()
   icons_by_filename = theme.icons_by_filename
   icons_by_file_extension = theme.icons_by_file_extension
   icons_by_operating_system = theme.icons_by_operating_system
-  icons = vim.tbl_extend("keep", {}, icons_by_filename, icons_by_file_extension, icons_by_operating_system)
+  icons_by_desktop_environment = theme.icons_by_desktop_environment
+  icons_by_window_manager = theme.icons_by_window_manager
+  icons = vim.tbl_extend(
+    "keep",
+    {},
+    icons_by_filename,
+    icons_by_file_extension,
+    icons_by_operating_system,
+    icons_by_desktop_environment,
+    icons_by_window_manager
+  )
   icons = vim.tbl_extend("force", icons, global_opts.override)
   icons[1] = default_icon
 end
@@ -345,6 +356,8 @@ function M.setup(opts)
   local user_filename_icons = user_icons.override_by_filename
   local user_file_ext_icons = user_icons.override_by_extension
   local user_operating_system_icons = user_icons.override_by_operating_system
+  local user_desktop_environment_icons = user_icons.override_by_desktop_environment
+  local user_window_manager_icons = user_icons.override_by_window_manager
 
   icons = vim.tbl_extend(
     "force",
@@ -352,7 +365,9 @@ function M.setup(opts)
     user_icons.override or {},
     user_filename_icons or {},
     user_file_ext_icons or {},
-    user_operating_system_icons or {}
+    user_operating_system_icons or {},
+    user_desktop_environment_icons or {},
+    user_window_manager_icons or {}
   )
   global_opts.override = vim.tbl_extend(
     "force",
@@ -360,7 +375,9 @@ function M.setup(opts)
     user_icons.override or {},
     user_filename_icons or {},
     user_file_ext_icons or {},
-    user_operating_system_icons or {}
+    user_operating_system_icons or {},
+    user_desktop_environment_icons or {},
+    user_window_manager_icons or {}
   )
 
   if user_filename_icons then
@@ -371,6 +388,12 @@ function M.setup(opts)
   end
   if user_operating_system_icons then
     icons_by_operating_system = vim.tbl_extend("force", icons_by_operating_system, user_operating_system_icons)
+  end
+  if user_desktop_environment_icons then
+    icons_by_desktop_environment = vim.tbl_extend("force", icons_by_desktop_environment, user_desktop_environment_icons)
+  end
+  if user_window_manager_icons then
+    icons_by_window_manager = vim.tbl_extend("force", icons_by_window_manager, user_window_manager_icons)
   end
 
   icons[1] = default_icon
@@ -390,7 +413,9 @@ function M.setup(opts)
       global_opts.override,
       icons_by_filename,
       icons_by_file_extension,
-      icons_by_operating_system
+      icons_by_operating_system,
+      icons_by_desktop_environment,
+      icons_by_window_manager
     )
   end, {
     desc = "nvim-web-devicons: highlight test",

--- a/lua/nvim-web-devicons/hi-test.lua
+++ b/lua/nvim-web-devicons/hi-test.lua
@@ -104,7 +104,17 @@ end
 ---@param icons_by_filename table[] filename "By File Name"
 ---@param icons_by_file_extension table[] extension "By File Extension"
 ---@param icons_by_operating_system table[] os "By Operating System"
-return function(default_icon, global_override, icons_by_filename, icons_by_file_extension, icons_by_operating_system)
+---@param icons_by_desktop_environment table[] os "By Desktop Environment"
+---@param icons_by_window_manager table[] os "By Window Manager"
+return function(
+  default_icon,
+  global_override,
+  icons_by_filename,
+  icons_by_file_extension,
+  icons_by_operating_system,
+  icons_by_desktop_environment,
+  icons_by_window_manager
+)
   -- create a buffer
   local bufnr = vim.api.nvim_create_buf(false, true)
 
@@ -116,7 +126,9 @@ return function(default_icon, global_override, icons_by_filename, icons_by_file_
   end
   l = render_icons(bufnr, l, icons_by_filename, "By File Name")
   l = render_icons(bufnr, l, icons_by_file_extension, "By File Extension")
-  render_icons(bufnr, l, icons_by_operating_system, "By Operating System")
+  l = render_icons(bufnr, l, icons_by_operating_system, "By Operating System")
+  l = render_icons(bufnr, l, icons_by_desktop_environment, "By Desktop Environment")
+  render_icons(bufnr, l, icons_by_window_manager, "By Window Manager")
 
   -- finalise and focus the buffer
   vim.api.nvim_buf_set_option(bufnr, "modifiable", false)

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -2398,9 +2398,79 @@ local icons_by_desktop_environment = {
   },
 }
 
+local icons_by_window_manager = {
+  ["awesomewm"] = {
+    icon = "",
+    color = "#535d6c",
+    cterm_color = "59",
+    name = "awesome",
+  },
+  ["bspwm"] = {
+    icon = "",
+    color = "#4f4f4f",
+    cterm_color = "239",
+    name = "BSPWM",
+  },
+  ["dwm"] = {
+    icon = "",
+    color = "#1177aa",
+    cterm_color = "31",
+    name = "dwm",
+  },
+  ["enlightenment"] = {
+    icon = "",
+    color = "#ffffff",
+    cterm_color = "231",
+    name = "Enlightenment",
+  },
+  ["fluxbox"] = {
+    icon = "",
+    color = "#555555",
+    cterm_color = "240",
+    name = "Fluxbox",
+  },
+  ["hyprland"] = {
+    icon = "",
+    color = "#00aaae",
+    cterm_color = "37",
+    name = "Hyprland",
+  },
+  ["i3"] = {
+    icon = "",
+    color = "#e8ebee",
+    cterm_color = "255",
+    name = "i3",
+  },
+  ["jwm"] = {
+    icon = "",
+    color = "#0078cd",
+    cterm_color = "32",
+    name = "JWM",
+  },
+  ["qtile"] = {
+    icon = "",
+    color = "#ffffff",
+    cterm_color = "231",
+    name = "Qtile",
+  },
+  ["sway"] = {
+    icon = "",
+    color = "#68751c",
+    cterm_color = "64",
+    name = "Sway",
+  },
+  ["xmonad"] = {
+    icon = "",
+    color = "#fd4d5d",
+    cterm_color = "203",
+    name = "xmonad",
+  },
+}
+
 return {
   icons_by_filename = icons_by_filename,
   icons_by_file_extension = icons_by_file_extension,
   icons_by_operating_system = icons_by_operating_system,
   icons_by_desktop_environment = icons_by_desktop_environment,
+  icons_by_window_manager = icons_by_window_manager,
 }

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -2171,12 +2171,6 @@ local icons_by_operating_system = {
     cterm_color = "38",
     name = "Artix",
   },
-  ["budgie"] = {
-    icon = "",
-    color = "#5195e3",
-    cterm_color = "68",
-    name = "Budgie",
-  },
   ["centos"] = {
     icon = "",
     color = "#a2518d",
@@ -2353,8 +2347,60 @@ local icons_by_operating_system = {
   },
 }
 
+local icons_by_desktop_environment = {
+  ["budgie"] = {
+    icon = "",
+    color = "#4e5361",
+    cterm_color = "240",
+    name = "Budgie",
+  },
+  ["cinnamon"] = {
+    icon = "",
+    color = "#dc682e",
+    cterm_color = "166",
+    name = "Cinnamon",
+  },
+  ["gnome"] = {
+    icon = "",
+    color = "#ffffff",
+    cterm_color = "231",
+    name = "GNOME",
+  },
+  ["lxde"] = {
+    icon = "",
+    color = "#a4a4a4",
+    cterm_color = "248",
+    name = "LXDE",
+  },
+  ["lxqt"] = {
+    icon = "",
+    color = "#0191d2",
+    cterm_color = "32",
+    name = "LXQt",
+  },
+  ["mate"] = {
+    icon = "",
+    color = "#9bda5c",
+    cterm_color = "113",
+    name = "MATE",
+  },
+  ["plasma"] = {
+    icon = "",
+    color = "#1b89f4",
+    cterm_color = "33",
+    name = "KDEPlasma",
+  },
+  ["xfce"] = {
+    icon = "",
+    color = "#00aadf",
+    cterm_color = "74",
+    name = "Xfce",
+  },
+}
+
 return {
   icons_by_filename = icons_by_filename,
   icons_by_file_extension = icons_by_file_extension,
   icons_by_operating_system = icons_by_operating_system,
+  icons_by_desktop_environment = icons_by_desktop_environment,
 }

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -2398,9 +2398,79 @@ local icons_by_desktop_environment = {
   },
 }
 
+local icons_by_window_manager = {
+  ["awesomewm"] = {
+    icon = "",
+    color = "#3e4651",
+    cterm_color = "238",
+    name = "awesome",
+  },
+  ["bspwm"] = {
+    icon = "",
+    color = "#4f4f4f",
+    cterm_color = "239",
+    name = "BSPWM",
+  },
+  ["dwm"] = {
+    icon = "",
+    color = "#0d5980",
+    cterm_color = "24",
+    name = "dwm",
+  },
+  ["enlightenment"] = {
+    icon = "",
+    color = "#333333",
+    cterm_color = "236",
+    name = "Enlightenment",
+  },
+  ["fluxbox"] = {
+    icon = "",
+    color = "#404040",
+    cterm_color = "238",
+    name = "Fluxbox",
+  },
+  ["hyprland"] = {
+    icon = "",
+    color = "#008082",
+    cterm_color = "30",
+    name = "Hyprland",
+  },
+  ["i3"] = {
+    icon = "",
+    color = "#2e2f30",
+    cterm_color = "236",
+    name = "i3",
+  },
+  ["jwm"] = {
+    icon = "",
+    color = "#005a9a",
+    cterm_color = "25",
+    name = "JWM",
+  },
+  ["qtile"] = {
+    icon = "",
+    color = "#333333",
+    cterm_color = "236",
+    name = "Qtile",
+  },
+  ["sway"] = {
+    icon = "",
+    color = "#4e5815",
+    cterm_color = "58",
+    name = "Sway",
+  },
+  ["xmonad"] = {
+    icon = "",
+    color = "#a9333e",
+    cterm_color = "131",
+    name = "xmonad",
+  },
+}
+
 return {
   icons_by_filename = icons_by_filename,
   icons_by_file_extension = icons_by_file_extension,
   icons_by_operating_system = icons_by_operating_system,
   icons_by_desktop_environment = icons_by_desktop_environment,
+  icons_by_window_manager = icons_by_window_manager,
 }

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -2171,12 +2171,6 @@ local icons_by_operating_system = {
     cterm_color = "31",
     name = "Artix",
   },
-  ["budgie"] = {
-    icon = "",
-    color = "#366397",
-    cterm_color = "25",
-    name = "Budgie",
-  },
   ["centos"] = {
     icon = "",
     color = "#7a3d6a",
@@ -2353,8 +2347,60 @@ local icons_by_operating_system = {
   },
 }
 
+local icons_by_desktop_environment = {
+  ["budgie"] = {
+    icon = "",
+    color = "#4e5361",
+    cterm_color = "240",
+    name = "Budgie",
+  },
+  ["cinnamon"] = {
+    icon = "",
+    color = "#93451f",
+    cterm_color = "124",
+    name = "Cinnamon",
+  },
+  ["gnome"] = {
+    icon = "",
+    color = "#333333",
+    cterm_color = "236",
+    name = "GNOME",
+  },
+  ["lxde"] = {
+    icon = "",
+    color = "#525252",
+    cterm_color = "239",
+    name = "LXDE",
+  },
+  ["lxqt"] = {
+    icon = "",
+    color = "#016d9e",
+    cterm_color = "24",
+    name = "LXQt",
+  },
+  ["mate"] = {
+    icon = "",
+    color = "#4e6d2e",
+    cterm_color = "22",
+    name = "MATE",
+  },
+  ["plasma"] = {
+    icon = "",
+    color = "#1467b7",
+    cterm_color = "25",
+    name = "KDEPlasma",
+  },
+  ["xfce"] = {
+    icon = "",
+    color = "#0080a7",
+    cterm_color = "31",
+    name = "Xfce",
+  },
+}
+
 return {
   icons_by_filename = icons_by_filename,
   icons_by_file_extension = icons_by_file_extension,
   icons_by_operating_system = icons_by_operating_system,
+  icons_by_desktop_environment = icons_by_desktop_environment,
 }

--- a/scripts/generate_colors.lua
+++ b/scripts/generate_colors.lua
@@ -147,16 +147,32 @@ if fn.search("^local icons_by_operating_system", "c") == 0 then
 end
 local lines3 = generate_lines()
 
-table.insert(lines3, "return {")
-table.insert(lines3, "  icons_by_filename = icons_by_filename,")
-table.insert(lines3, "  icons_by_file_extension = icons_by_file_extension,")
-table.insert(lines3, "  icons_by_operating_system = icons_by_operating_system,")
-table.insert(lines3, "}")
+-- fourth table
+if fn.search("^local icons_by_desktop_environment", "c") == 0 then
+  error_exit("Table 'icons_by_desktop_environment' not found in lua/nvim-web-devicons/icons-default.lua", 1)
+end
+local lines4 = generate_lines()
+
+-- fifth table
+if fn.search("^local icons_by_window_manager", "c") == 0 then
+  error_exit("Table 'icons_by_window_manager' not found in lua/nvim-web-devicons/icons-default.lua", 1)
+end
+local lines5 = generate_lines()
+
+table.insert(lines5, "return {")
+table.insert(lines5, "  icons_by_filename = icons_by_filename,")
+table.insert(lines5, "  icons_by_file_extension = icons_by_file_extension,")
+table.insert(lines5, "  icons_by_operating_system = icons_by_operating_system,")
+table.insert(lines5, "  icons_by_desktop_environment = icons_by_desktop_environment,")
+table.insert(lines5, "  icons_by_window_manager = icons_by_window_manager,")
+table.insert(lines5, "}")
 
 -- write both tables to file
 fn.writefile(lines, "lua/nvim-web-devicons/icons-light.lua")
 fn.writefile(lines2, "lua/nvim-web-devicons/icons-light.lua", "a")
 fn.writefile(lines3, "lua/nvim-web-devicons/icons-light.lua", "a")
+fn.writefile(lines4, "lua/nvim-web-devicons/icons-light.lua", "a")
+fn.writefile(lines5, "lua/nvim-web-devicons/icons-light.lua", "a")
 
 print "Finished creating new file!"
 


### PR DESCRIPTION
Bifurcation from #433 

I tried to use "official" color of the logos but the darker ones were adjusted a bit. dwm uses the suckless color.

I'm not sure what causes the error in Xterm, I need to look for a patched font to test there and urxvt, Symbols only fallbacks on Alacritty.

Does this PR causes also problem?

Fix #432 