### PR TITLE
fix: get_icon_color() is now case insensitive

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -461,7 +461,7 @@ local function get_icon_by_extension(name, ext, opts)
   return iterate_multi_dotted_extension(name, icon_table)
 end
 
-function M.get_icon(name, ext, opts)
+local function get_icon_data(name, ext, opts)
   if type(name) == "string" then
     name = name:lower()
   end
@@ -478,6 +478,12 @@ function M.get_icon(name, ext, opts)
   else
     icon_data = icons[name] or get_icon_by_extension(name, ext, opts) or (has_default and default_icon)
   end
+
+  return icon_data
+end
+
+function M.get_icon(name, ext, opts)
+  local icon_data = get_icon_data(name, ext, opts)
 
   if icon_data then
     return icon_data.icon, get_highlight_name(icon_data)
@@ -496,18 +502,7 @@ function M.get_icon_by_filetype(ft, opts)
 end
 
 function M.get_icon_colors(name, ext, opts)
-  if not loaded then
-    M.setup()
-  end
-
-  local has_default = if_nil(opts and opts.default, global_opts.default)
-  local is_strict = if_nil(opts and opts.strict, global_opts.strict)
-  local icon_data
-  if is_strict then
-    icon_data = icons_by_filename[name] or get_icon_by_extension(name, ext, opts) or (has_default and default_icon)
-  else
-    icon_data = icons[name] or get_icon_by_extension(name, ext, opts) or (has_default and default_icon)
-  end
+  local icon_data = get_icon_data(name, ext, opts)
 
   if icon_data then
     local color = icon_data.color


### PR DESCRIPTION
Problem: `get_icon_color()` does not find icons for files whose names are capitalized and which don't have extensions, such as "LICENSE", "License", or "COMMIT_EDITMSG". This is inconsistent with the functionality of `get_icon()`, which does lowercase the name parameter.

Solution: Lowercase the name parameter in get_icon_color(). Coincidentally, get_icon() and get_icon_color() have a lot of duplicate functionality at the front of the function, specifically to get the entire icon data. Abstract this functionality out to a local function that can be shared by these other two functions, which are now wrapper functions that return different data.