### PR TITLE
fix(#456): adding gulpfile/gruntfile extensions for js and other js types

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -380,13 +380,13 @@ local icons_by_filename = {
   ["gruntfile.babel.js"] = {
     icon = "",
     color = "#e37933",
-    cterm_color = "167",
+    cterm_color = "166",
     name = "Gruntfile",
   },
   ["gruntfile.coffee"] = {
     icon = "",
     color = "#e37933",
-    cterm_color = "167",
+    cterm_color = "166",
     name = "Gruntfile",
   },
   ["gruntfile.js"] = {
@@ -398,7 +398,7 @@ local icons_by_filename = {
   ["gruntfile.ts"] = {
     icon = "",
     color = "#e37933",
-    cterm_color = "167",
+    cterm_color = "166",
     name = "Gruntfile",
   },
   ["gtkrc"] = {

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -377,10 +377,28 @@ local icons_by_filename = {
     cterm_color = "24",
     name = "Groovy",
   },
-  ["gruntfile"] = {
+  ["gruntfile.babel.js"] = {
+    icon = "",
+    color = "#e37933",
+    cterm_color = "167",
+    name = "Gruntfile",
+  },
+  ["gruntfile.coffee"] = {
+    icon = "",
+    color = "#e37933",
+    cterm_color = "167",
+    name = "Gruntfile",
+  },
+  ["gruntfile.js"] = {
     icon = "",
     color = "#e37933",
     cterm_color = "166",
+    name = "Gruntfile",
+  },
+  ["gruntfile.ts"] = {
+    icon = "",
+    color = "#e37933",
+    cterm_color = "167",
     name = "Gruntfile",
   },
   ["gtkrc"] = {
@@ -389,7 +407,25 @@ local icons_by_filename = {
     cterm_color = "231",
     name = "GTK",
   },
-  ["gulpfile"] = {
+  ["gulpfile.babel.js"] = {
+    icon = "",
+    color = "#cc3e44",
+    cterm_color = "167",
+    name = "Gulpfile",
+  },
+  ["gulpfile.coffee"] = {
+    icon = "",
+    color = "#cc3e44",
+    cterm_color = "167",
+    name = "Gulpfile",
+  },
+  ["gulpfile.js"] = {
+    icon = "",
+    color = "#cc3e44",
+    cterm_color = "167",
+    name = "Gulpfile",
+  },
+  ["gulpfile.ts"] = {
     icon = "",
     color = "#cc3e44",
     cterm_color = "167",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -377,7 +377,25 @@ local icons_by_filename = {
     cterm_color = "239",
     name = "Groovy",
   },
-  ["gruntfile"] = {
+  ["gruntfile.babel.js"] = {
+    icon = "",
+    color = "#975122",
+    cterm_color = "130",
+    name = "Gruntfile",
+  },
+  ["gruntfile.coffee"] = {
+    icon = "",
+    color = "#975122",
+    cterm_color = "130",
+    name = "Gruntfile",
+  },
+  ["gruntfile.js"] = {
+    icon = "",
+    color = "#975122",
+    cterm_color = "130",
+    name = "Gruntfile",
+  },
+  ["gruntfile.ts"] = {
     icon = "",
     color = "#975122",
     cterm_color = "130",
@@ -389,7 +407,25 @@ local icons_by_filename = {
     cterm_color = "236",
     name = "GTK",
   },
-  ["gulpfile"] = {
+  ["gulpfile.babel.js"] = {
+    icon = "",
+    color = "#992e33",
+    cterm_color = "88",
+    name = "Gulpfile",
+  },
+  ["gulpfile.coffee"] = {
+    icon = "",
+    color = "#992e33",
+    cterm_color = "88",
+    name = "Gulpfile",
+  },
+  ["gulpfile.js"] = {
+    icon = "",
+    color = "#992e33",
+    cterm_color = "88",
+    name = "Gulpfile",
+  },
+  ["gulpfile.ts"] = {
     icon = "",
     color = "#992e33",
     cterm_color = "88",


### PR DESCRIPTION
resolves #456, now gulpfile/gruntfile.js, .ts, .babel.js, .coffee will have their proper icons instead of standard JS icon

demo:
nvim-tree
![image](https://github.com/nvim-tree/nvim-web-devicons/assets/100977778/c0256ec9-c405-4b0b-9901-9f3ee322f0e2)
telescope
![image](https://github.com/nvim-tree/nvim-web-devicons/assets/100977778/ab9b7688-700a-45f8-9a82-ccb744b137f4)
bufferline
![image](https://github.com/nvim-tree/nvim-web-devicons/assets/100977778/02ce158a-7d02-4b6e-ba7a-35e01c8b9461)
should work across all plugins that have nvim-web-devicons as dependencies