### PR TITLE
feat: add mojo

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -3497,6 +3497,12 @@ local icons_by_operating_system = {
     cterm_color = "196",
     name = "Mojo",
   },
+  ["🔥"] = {
+    icon = "",
+    color = "#ff4c1f",
+    cterm_color = "196",
+    name = "Mojo",
+  },
   ["mxlinux"] = {
     icon = "",
     color = "#ffffff",

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -3473,12 +3473,6 @@ local icons_by_operating_system = {
     cterm_color = "238",
     name = "LXLE",
   },
-  ["mint"] = {
-    icon = "󰣭",
-    color = "#66af3d",
-    cterm_color = "70",
-    name = "Mint",
-  },
   ["mageia"] = {
     icon = "",
     color = "#2397d4",
@@ -3490,6 +3484,18 @@ local icons_by_operating_system = {
     color = "#33b959",
     cterm_color = "35",
     name = "Manjaro",
+  },
+  ["mint"] = {
+    icon = "󰣭",
+    color = "#66af3d",
+    cterm_color = "70",
+    name = "Mint",
+  },
+  ["mojo"] = {
+    icon = "󰈸",
+    color = "#ff4c1f",
+    cterm_color = "196",
+    name = "Mojo",
   },
   ["mxlinux"] = {
     icon = "",

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -3492,7 +3492,7 @@ local icons_by_operating_system = {
     name = "Mint",
   },
   ["mojo"] = {
-    icon = "󰈸",
+    icon = "",
     color = "#ff4c1f",
     cterm_color = "196",
     name = "Mojo",

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -2210,6 +2210,18 @@ local icons_by_file_extension = {
     cterm_color = "215",
     name = "Mobi",
   },
+  ["mojo"] = {
+    icon = "",
+    color = "#ff4c1f",
+    cterm_color = "196",
+    name = "Mojo",
+  },
+  ["🔥"] = {
+    icon = "",
+    color = "#ff4c1f",
+    cterm_color = "196",
+    name = "Mojo",
+  },
   ["mov"] = {
     icon = "",
     color = "#FD971F",
@@ -3490,18 +3502,6 @@ local icons_by_operating_system = {
     color = "#66af3d",
     cterm_color = "70",
     name = "Mint",
-  },
-  ["mojo"] = {
-    icon = "",
-    color = "#ff4c1f",
-    cterm_color = "196",
-    name = "Mojo",
-  },
-  ["🔥"] = {
-    icon = "",
-    color = "#ff4c1f",
-    cterm_color = "196",
-    name = "Mojo",
   },
   ["mxlinux"] = {
     icon = "",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -3492,7 +3492,7 @@ local icons_by_operating_system = {
     name = "Mint",
   },
   ["mojo"] = {
-    icon = "󰈸",
+    icon = "",
     color = "#bf3917",
     cterm_color = "160",
     name = "Mojo",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -3473,12 +3473,6 @@ local icons_by_operating_system = {
     cterm_color = "238",
     name = "LXLE",
   },
-  ["mint"] = {
-    icon = "󰣭",
-    color = "#447529",
-    cterm_color = "28",
-    name = "Mint",
-  },
   ["mageia"] = {
     icon = "",
     color = "#1a719f",
@@ -3490,6 +3484,18 @@ local icons_by_operating_system = {
     color = "#227b3b",
     cterm_color = "29",
     name = "Manjaro",
+  },
+  ["mint"] = {
+    icon = "󰣭",
+    color = "#447529",
+    cterm_color = "28",
+    name = "Mint",
+  },
+  ["mojo"] = {
+    icon = "󰈸",
+    color = "#bf3917",
+    cterm_color = "160",
+    name = "Mojo",
   },
   ["mxlinux"] = {
     icon = "",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -3497,6 +3497,12 @@ local icons_by_operating_system = {
     cterm_color = "160",
     name = "Mojo",
   },
+  ["🔥"] = {
+    icon = "",
+    color = "#bf3917",
+    cterm_color = "160",
+    name = "Mojo",
+  },
   ["mxlinux"] = {
     icon = "",
     color = "#333333",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -2210,6 +2210,18 @@ local icons_by_file_extension = {
     cterm_color = "94",
     name = "Mobi",
   },
+  ["mojo"] = {
+    icon = "",
+    color = "#bf3917",
+    cterm_color = "160",
+    name = "Mojo",
+  },
+  ["🔥"] = {
+    icon = "",
+    color = "#bf3917",
+    cterm_color = "160",
+    name = "Mojo",
+  },
   ["mov"] = {
     icon = "",
     color = "#7e4c10",
@@ -3490,18 +3502,6 @@ local icons_by_operating_system = {
     color = "#447529",
     cterm_color = "28",
     name = "Mint",
-  },
-  ["mojo"] = {
-    icon = "",
-    color = "#bf3917",
-    cterm_color = "160",
-    name = "Mojo",
-  },
-  ["🔥"] = {
-    icon = "",
-    color = "#bf3917",
-    cterm_color = "160",
-    name = "Mojo",
   },
   ["mxlinux"] = {
     icon = "",


### PR DESCRIPTION
The changes in the PR would add an icon for mojo.

- Used color is the linguist color
- Used icon is nf-md-fire as a font-icon looks better in the tree as a unicode emoji character and is less likely to set things off. If the emoji is the preferred choice, please let me know, I don't have a strong preference here. 