### PR TITLE
fix: update .babelrc icon

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1888,8 +1888,8 @@ local icons_by_file_extension = {
   },
   ["jsx"] = {
     icon = "",
-    color = "#f7df1e",
-    cterm_color = "220",
+    color = "#20c2e3",
+    cterm_color = "45",
     name = "Jsx",
   },
   ["jxl"] = {
@@ -3046,8 +3046,8 @@ local icons_by_file_extension = {
   },
   ["tsx"] = {
     icon = "",
-    color = "#20c2e3",
-    cterm_color = "45",
+    color = "#1354bf",
+    cterm_color = "26",
     name = "Tsx",
   },
   ["ttf"] = {

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -12,7 +12,7 @@ local icons_by_filename = {
     name = "GradleSettings",
   },
   [".babelrc"] = {
-    icon = "",
+    icon = "",
     color = "#cbcb41",
     cterm_color = "185",
     name = "Babelrc",

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1888,8 +1888,8 @@ local icons_by_file_extension = {
   },
   ["jsx"] = {
     icon = "",
-    color = "#20c2e3",
-    cterm_color = "45",
+    color = "#f7df1e",
+    cterm_color = "220",
     name = "Jsx",
   },
   ["jxl"] = {
@@ -3046,8 +3046,8 @@ local icons_by_file_extension = {
   },
   ["tsx"] = {
     icon = "",
-    color = "#1354bf",
-    cterm_color = "26",
+    color = "#20c2e3",
+    cterm_color = "45",
     name = "Tsx",
   },
   ["ttf"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1888,8 +1888,8 @@ local icons_by_file_extension = {
   },
   ["jsx"] = {
     icon = "",
-    color = "#524a0a",
-    cterm_color = "58",
+    color = "#158197",
+    cterm_color = "31",
     name = "Jsx",
   },
   ["jxl"] = {
@@ -3046,8 +3046,8 @@ local icons_by_file_extension = {
   },
   ["tsx"] = {
     icon = "",
-    color = "#158197",
-    cterm_color = "31",
+    color = "#1354bf",
+    cterm_color = "26",
     name = "Tsx",
   },
   ["ttf"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1888,8 +1888,8 @@ local icons_by_file_extension = {
   },
   ["jsx"] = {
     icon = "",
-    color = "#158197",
-    cterm_color = "31",
+    color = "#524a0a",
+    cterm_color = "58",
     name = "Jsx",
   },
   ["jxl"] = {
@@ -3046,8 +3046,8 @@ local icons_by_file_extension = {
   },
   ["tsx"] = {
     icon = "",
-    color = "#1354bf",
-    cterm_color = "26",
+    color = "#158197",
+    cterm_color = "31",
     name = "Tsx",
   },
   ["ttf"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -12,7 +12,7 @@ local icons_by_filename = {
     name = "GradleSettings",
   },
   [".babelrc"] = {
-    icon = "",
+    icon = "",
     color = "#666620",
     cterm_color = "58",
     name = "Babelrc",


### PR DESCRIPTION
The changes in the PR would update icon for `.bablerc` file and React File colors

- Update babelrc icon to `nf-seti-babel` (e639)

To diiferenciate between `jsx` and `tsx` files.  Changed `jsx` color to **yellow**. Because it will be easier to work with js and jsx files. TSX color changed to Previous JSX color

## Previous JSX with JS
![Screenshot from 2024-06-07 15-55-15](https://github.com/nvim-tree/nvim-web-devicons/assets/118371892/afeaa4b5-9f9e-4e4a-9cf1-d6c1b79a3b14)

## After Changing Colors
![Screenshot from 2024-06-07 15-56-15](https://github.com/nvim-tree/nvim-web-devicons/assets/118371892/589bb481-8d47-47a6-abce-0355895510f3)

