### PR TITLE
feat: add .go.mod, .go.sum, .go.work

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -365,6 +365,24 @@ local icons_by_filename = {
     cterm_color = "66",
     name = "Makefile",
   },
+  ["go.mod"] = {
+    icon = "",
+    color = "#519aba",
+    cterm_color = "74",
+    name = "GoMod",
+  },
+  ["go.sum"] = {
+    icon = "",
+    color = "#519aba",
+    cterm_color = "74",
+    name = "GoSum",
+  },
+  ["go.work"] = {
+    icon = "",
+    color = "#519aba",
+    cterm_color = "74",
+    name = "GoWork",
+  },
   ["gradlew"] = {
     icon = "",
     color = "#005f87",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -365,6 +365,24 @@ local icons_by_filename = {
     cterm_color = "59",
     name = "Makefile",
   },
+  ["go.mod"] = {
+    icon = "",
+    color = "#36677c",
+    cterm_color = "24",
+    name = "GoMod",
+  },
+  ["go.sum"] = {
+    icon = "",
+    color = "#36677c",
+    cterm_color = "24",
+    name = "GoSum",
+  },
+  ["go.work"] = {
+    icon = "",
+    color = "#36677c",
+    cterm_color = "24",
+    name = "GoWork",
+  },
   ["gradlew"] = {
     icon = "",
     color = "#005f87",


### PR DESCRIPTION
#288 

- [x] colors & icon consistent with ["go"]
- [x] `make` finished successfully. 
```
stylua . --check
luacheck lua scripts
Checking lua/nvim-web-devicons.lua                OK
Checking lua/nvim-web-devicons/hi-test.lua        OK
Checking lua/nvim-web-devicons/icons-default.lua  OK
Checking lua/nvim-web-devicons/icons-light.lua    OK
Checking scripts/generate_colors.lua              OK

Total: 0 warnings / 0 errors in 5 files
```