### PR TITLE
fix(gleam): move from icons_by_filename to icons_by_file_extension

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -101,12 +101,6 @@ local icons_by_filename = {
     cterm_color = "196",
     name = "GitModules",
   },
-  [".gleam"] = {
-    icon = "",
-    color = "#ffaff3",
-    cterm_color = "219",
-    name = "Gleam",
-  },
   [".gtkrc-2.0"] = {
     icon = "",
     color = "#ffffff",
@@ -1777,6 +1771,12 @@ local icons_by_file_extension = {
     color = "#FFB13B",
     cterm_color = "214",
     name = "BinaryGLTF",
+  },
+  ["gleam"] = {
+    icon = "",
+    color = "#ffaff3",
+    cterm_color = "219",
+    name = "Gleam",
   },
   ["gnumakefile"] = {
     icon = "",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -101,12 +101,6 @@ local icons_by_filename = {
     cterm_color = "160",
     name = "GitModules",
   },
-  [".gleam"] = {
-    icon = "",
-    color = "#553a51",
-    cterm_color = "53",
-    name = "Gleam",
-  },
   [".gtkrc-2.0"] = {
     icon = "",
     color = "#333333",
@@ -1777,6 +1771,12 @@ local icons_by_file_extension = {
     color = "#80581e",
     cterm_color = "94",
     name = "BinaryGLTF",
+  },
+  ["gleam"] = {
+    icon = "",
+    color = "#553a51",
+    cterm_color = "53",
+    name = "Gleam",
   },
   ["gnumakefile"] = {
     icon = "",


### PR DESCRIPTION
According to the documentation
> There are two tables where icons can be added:
> 1. icons_by_filename
> 2. icons_by_file_extension
>
> Add the icon in table 1. if the icon is for a file that is always named that
> way, for example `.gitconfig`. Add to table 2. if the icon is for all files
> with an extension.

the Gleam icon must be placed under `icons_by_file_extension`

Disclaimer: it was not working for me and that's the reason