### PR TITLE
feat: add variant="light|dark" option to override &background

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ require'nvim-web-devicons'.setup {
  -- because its name happened to match some extension (default to false)
  strict = true;
  -- set the light or dark variant manually, instead of relying on `background`
- -- (default to "auto")
+ -- (default to nil)
  variant = "light|dark";
  -- same as `override` but specifically for overrides by filename
  -- takes effect when `strict` is true

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Run `:NvimWebDeviconsHiTest` to see all icons and their highlighting.
 
 ### Variants
 
-Light or dark color variants of the icons depend on `&background`.
+Light or dark color variants of the icons depend on `&background`.  
+The variant can also be set manually in `setup` with the `variant` option.
 
 The variant is updated:
 - on `OptionSet` event for `background`, or
@@ -75,6 +76,9 @@ require'nvim-web-devicons'.setup {
  -- prevents cases when file doesn't have any extension but still gets some icon
  -- because its name happened to match some extension (default to false)
  strict = true;
+ -- set the light or dark variant manually, instead of relying on `background`
+ -- (default to "auto")
+ variant = "light|dark";
  -- same as `override` but specifically for overrides by filename
  -- takes effect when `strict` is true
  override_by_filename = {

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -40,12 +40,19 @@ local global_opts = {
   strict = false,
   default = false,
   color_icons = true,
+  variant = "auto",
 }
 
 -- Set the current icons tables, depending on the 'background' option.
 local function refresh_icons()
   local theme
-  if vim.o.background == "light" then
+  if global_opts.variant == "auto" then
+    if vim.o.background == "light" then
+      theme = require "nvim-web-devicons.icons-light"
+    else
+      theme = require "nvim-web-devicons.icons-default"
+    end
+  elseif global_opts.variant == "light" then
     theme = require "nvim-web-devicons.icons-light"
   else
     theme = require "nvim-web-devicons.icons-default"
@@ -371,6 +378,11 @@ function M.setup(opts)
   end
 
   global_opts.color_icons = if_nil(user_icons.color_icons, global_opts.color_icons)
+
+  if user_icons.variant == "light" or user_icons.variant == "dark" then
+    global_opts.variant = user_icons.variant
+    refresh_icons()
+  end
 
   if user_icons.override and user_icons.override.default_icon then
     default_icon = user_icons.override.default_icon

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -40,22 +40,22 @@ local global_opts = {
   strict = false,
   default = false,
   color_icons = true,
-  variant = "auto",
+  variant = nil,
 }
 
 -- Set the current icons tables, depending on the 'background' option.
 local function refresh_icons()
   local theme
-  if global_opts.variant == "auto" then
+  if global_opts.variant == "light" then
+    theme = require "nvim-web-devicons.icons-light"
+  elseif global_opts.variant == "dark" then
+    theme = require "nvim-web-devicons.icons-default"
+  else
     if vim.o.background == "light" then
       theme = require "nvim-web-devicons.icons-light"
     else
       theme = require "nvim-web-devicons.icons-default"
     end
-  elseif global_opts.variant == "light" then
-    theme = require "nvim-web-devicons.icons-light"
-  else
-    theme = require "nvim-web-devicons.icons-default"
   end
 
   icons_by_filename = theme.icons_by_filename
@@ -381,8 +381,10 @@ function M.setup(opts)
 
   if user_icons.variant == "light" or user_icons.variant == "dark" then
     global_opts.variant = user_icons.variant
-    refresh_icons()
   end
+
+  -- Load the icons after setting variant option
+  refresh_icons()
 
   if user_icons.override and user_icons.override.default_icon then
     default_icon = user_icons.override.default_icon
@@ -590,9 +592,6 @@ function M.set_default_icon(icon, color, cterm_color)
   default_icon.cterm_color = cterm_color
   set_up_highlight(default_icon)
 end
-
--- Load the icons already, the loaded tables depend on the 'background' setting.
-refresh_icons()
 
 function M.refresh()
   refresh_icons()


### PR DESCRIPTION
PR for the discussion here: https://github.com/nvim-tree/nvim-web-devicons/discussions/491#discussioncomment-10649821

I have a few questions about the code. Right now, `refresh_icons()` is called directly in the `nvim-web-devicons.lua` file. However, now that I'm adding an option which the `refresh_icons()` function depends on, should I move the call into the `setup()` function? Right now im just calling `refresh_icons()` again if the variant option is not "auto", which is a bit inefficient.