### PR TITLE
feat: add hyprpaper icons

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -593,6 +593,12 @@ local icons_by_filename = {
     cterm_color = "37",
     name = "Hyprlock",
   },
+  ["hyprpaper.conf"] = {
+    icon = "",
+    color = "#00aaae",
+    cterm_color = "37",
+    name = "Hyprpaper",
+  },
   ["i18n.config.js"] = {
     icon = "󰗊",
     color = "#7986cb",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -593,6 +593,12 @@ local icons_by_filename = {
     cterm_color = "30",
     name = "Hyprlock",
   },
+  ["hyprpaper.conf"] = {
+    icon = "",
+    color = "#008082",
+    cterm_color = "30",
+    name = "Hyprpaper",
+  },
   ["i18n.config.js"] = {
     icon = "󰗊",
     color = "#515987",


### PR DESCRIPTION
Add's suport for hyprpaper (https://github.com/hyprwm/hyprpaper) config files, using the same config as the rest of the hypr suite.