### PR TITLE
feat: add bun.lockb

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -311,6 +311,12 @@ local icons_by_filename = {
     cterm_color = "172",
     name = "ZigObjectNotation",
   },
+  ["bun.lockb"] = {
+    icon = "",
+    color = "#eadcd1",
+    cterm_color = "253",
+    name = "BunLockfile",
+  },
   ["checkhealth"] = {
     icon = "󰓙",
     color = "#75B4FB",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -311,6 +311,12 @@ local icons_by_filename = {
     cterm_color = "94",
     name = "ZigObjectNotation",
   },
+  ["bun.lockb"] = {
+    icon = "",
+    color = "#4e4946",
+    cterm_color = "239",
+    name = "BunLockfile",
+  },
   ["checkhealth"] = {
     icon = "󰓙",
     color = "#3a5a7e",


### PR DESCRIPTION
## Description
This commit adds the bun icon for bun's lockfile (bun.lockb). The latest release of nerdfonts (v3.3.0) adds the bun icon.
## Icon 
![image](https://github.com/user-attachments/assets/3f35f850-b467-4f70-88c4-6306d2e0ade3)
Taken from [nerdfont cheat-sheet](https://www.nerdfonts.com/cheat-sheet)
## Screenshot
![image](https://github.com/user-attachments/assets/24bbd0d5-f488-40f3-8545-1194f5ffa5bb)
