### PR TITLE
feat: add many icons

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -3893,6 +3893,12 @@ local icons_by_operating_system = {
     cterm_color = "32",
     name = "Kubuntu",
   },
+  ["leap"] = {
+    icon = "",
+    color = "#FBC75D",
+    cterm_color = "221",
+    name = "Leap",
+  },
   ["locos"] = {
     icon = "",
     color = "#fab402",
@@ -3934,6 +3940,12 @@ local icons_by_operating_system = {
     color = "#7ab1db",
     cterm_color = "110",
     name = "NixOS",
+  },
+  ["nobara"] = {
+    icon = "",
+    color = "#ffffff",
+    cterm_color = "231",
+    name = "NobaraLinux",
   },
   ["openbsd"] = {
     icon = "",
@@ -4030,6 +4042,12 @@ local icons_by_operating_system = {
     color = "#0f58b6",
     cterm_color = "25",
     name = "TrisquelGNULinux",
+  },
+  ["tumbleweed"] = {
+    icon = "",
+    color = "#35B9AB",
+    cterm_color = "37",
+    name = "Tumbleweed",
   },
   ["ubuntu"] = {
     icon = "",
@@ -4168,6 +4186,12 @@ local icons_by_window_manager = {
     color = "#ffffff",
     cterm_color = "231",
     name = "Qtile",
+  },
+  ["river"] = {
+    icon = "",
+    color = "#000000",
+    cterm_color = "16",
+    name = "river",
   },
   ["sway"] = {
     icon = "",

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -17,6 +17,30 @@ local icons_by_filename = {
     cterm_color = "113",
     name = "Bashrc",
   },
+  [".clang-format"] = {
+    icon = "",
+    color = "#6d8086",
+    cterm_color = "66",
+    name = "ClangConfig",
+  },
+  [".clang-tidy"] = {
+    icon = "",
+    color = "#6d8086",
+    cterm_color = "66",
+    name = "ClangConfig",
+  },
+  [".codespellrc"] = {
+    icon = "󰓆",
+    color = "#35DA60",
+    cterm_color = "41",
+    name = "Codespell",
+  },
+  [".condarc"] = {
+    icon = "",
+    color = "#43b02a",
+    cterm_color = "34",
+    name = "Conda",
+  },
   [".dockerignore"] = {
     icon = "󰡨",
     color = "#458ee6",
@@ -107,6 +131,12 @@ local icons_by_filename = {
     cterm_color = "66",
     name = "Justfile",
   },
+  [".luacheckrc"] = {
+    icon = "",
+    color = "#00a2ff",
+    cterm_color = "75",
+    name = "Luaurc",
+  },
   [".luaurc"] = {
     icon = "",
     color = "#00a2ff",
@@ -118,6 +148,12 @@ local icons_by_filename = {
     color = "#f54d27",
     cterm_color = "196",
     name = "Mailmap",
+  },
+  [".nanorc"] = {
+    icon = "",
+    color = "#440077",
+    cterm_color = "54",
+    name = "Nano",
   },
   [".npmignore"] = {
     icon = "",
@@ -142,6 +178,12 @@ local icons_by_filename = {
     color = "#5FA04E",
     cterm_color = "71",
     name = "node",
+  },
+  [".pre-commit-config.yaml"] = {
+    icon = "󰛢",
+    color = "#F8B424",
+    cterm_color = "214",
+    name = "PreCommitConfig",
   },
   [".prettierrc"] = {
     icon = "",
@@ -202,6 +244,12 @@ local icons_by_filename = {
     color = "#4285F4",
     cterm_color = "33",
     name = "PrettierIgnore",
+  },
+  [".pylintrc"] = {
+    icon = "",
+    color = "#6d8086",
+    cterm_color = "66",
+    name = "PyLintConfig",
   },
   [".settings.json"] = {
     icon = "",
@@ -324,9 +372,9 @@ local icons_by_filename = {
     name = "Checkhealth",
   },
   ["cmakelists.txt"] = {
-    icon = "",
-    color = "#6d8086",
-    cterm_color = "66",
+    icon = "",
+    color = "#dce3eb",
+    cterm_color = "254",
     name = "CMakeLists",
   },
   ["code_of_conduct"] = {
@@ -839,6 +887,18 @@ local icons_by_filename = {
     cterm_color = "52",
     name = "Rakefile",
   },
+  ["readme"] = {
+    icon = "󰂺",
+    color = "#ededed",
+    cterm_color = "255",
+    name = "Readme",
+  },
+  ["readme.md"] = {
+    icon = "󰂺",
+    color = "#ededed",
+    cterm_color = "255",
+    name = "Readme",
+  },
   ["rmd"] = {
     icon = "",
     color = "#519aba",
@@ -1311,9 +1371,9 @@ local icons_by_file_extension = {
     name = "ClojureDart",
   },
   ["cmake"] = {
-    icon = "",
-    color = "#6d8086",
-    cterm_color = "66",
+    icon = "",
+    color = "#dce3eb",
+    cterm_color = "254",
     name = "CMake",
   },
   ["cob"] = {
@@ -1333,6 +1393,12 @@ local icons_by_file_extension = {
     color = "#cbcb41",
     cterm_color = "185",
     name = "Coffee",
+  },
+  ["conda"] = {
+    icon = "",
+    color = "#43b02a",
+    cterm_color = "34",
+    name = "Conda",
   },
   ["conf"] = {
     icon = "",
@@ -1772,6 +1838,12 @@ local icons_by_file_extension = {
     cterm_color = "43",
     name = "Fdmdownload",
   },
+  ["fish"] = {
+    icon = "",
+    color = "#4d5a5e",
+    cterm_color = "240",
+    name = "Fish",
+  },
   ["flac"] = {
     icon = "",
     color = "#0075aa",
@@ -1795,12 +1867,6 @@ local icons_by_file_extension = {
     color = "#fff3d7",
     cterm_color = "230",
     name = "Fennel",
-  },
-  ["fish"] = {
-    icon = "",
-    color = "#4d5a5e",
-    cterm_color = "240",
-    name = "Fish",
   },
   ["fs"] = {
     icon = "",
@@ -2127,9 +2193,9 @@ local icons_by_file_extension = {
     name = "Iso",
   },
   ["ipynb"] = {
-    icon = "",
-    color = "#51a0cf",
-    cterm_color = "74",
+    icon = "",
+    color = "#f57d01",
+    cterm_color = "208",
     name = "Notebook",
   },
   ["java"] = {
@@ -3380,6 +3446,12 @@ local icons_by_file_extension = {
     cterm_color = "214",
     name = "Txz",
   },
+  ["typ"] = {
+    icon = "",
+    color = "#0dbcc0",
+    cterm_color = "37",
+    name = "Typst",
+  },
   ["typoscript"] = {
     icon = "",
     color = "#FF8700",
@@ -3405,8 +3477,8 @@ local icons_by_file_extension = {
     name = "Verilog",
   },
   ["vala"] = {
-    icon = "",
-    color = "#7239b3",
+    icon = "",
+    color = "#7b3db9",
     cterm_color = "91",
     name = "Vala",
   },
@@ -3427,6 +3499,12 @@ local icons_by_file_extension = {
     color = "#019833",
     cterm_color = "28",
     name = "VHDL",
+  },
+  ["vi"] = {
+    icon = "",
+    color = "#fec60a",
+    cterm_color = "220",
+    name = "LabView",
   },
   ["vim"] = {
     icon = "",

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1868,6 +1868,30 @@ local icons_by_file_extension = {
     cterm_color = "230",
     name = "Fennel",
   },
+  ["fodg"] = {
+    icon = "",
+    color = "#FFFB57",
+    cterm_color = "227",
+    name = "LibreOfficeGraphics",
+  },
+  ["fodp"] = {
+    icon = "",
+    color = "#FE9C45",
+    cterm_color = "215",
+    name = "LibreOfficeImpress",
+  },
+  ["fods"] = {
+    icon = "",
+    color = "#78FC4E",
+    cterm_color = "119",
+    name = "LibreOfficeCalc",
+  },
+  ["fodt"] = {
+    icon = "",
+    color = "#2DCBFD",
+    cterm_color = "81",
+    name = "LibreOfficeWriter",
+  },
   ["fs"] = {
     icon = "",
     color = "#519aba",
@@ -2690,6 +2714,36 @@ local icons_by_file_extension = {
     cterm_color = "102",
     name = "3DObjectFile",
   },
+  ["odf"] = {
+    icon = "",
+    color = "#FF5A96",
+    cterm_color = "204",
+    name = "LibreOfficeFormula",
+  },
+  ["odg"] = {
+    icon = "",
+    color = "#FFFB57",
+    cterm_color = "227",
+    name = "LibreOfficeGraphics",
+  },
+  ["odp"] = {
+    icon = "",
+    color = "#FE9C45",
+    cterm_color = "215",
+    name = "LibreOfficeImpress",
+  },
+  ["ods"] = {
+    icon = "",
+    color = "#78FC4E",
+    cterm_color = "119",
+    name = "LibreOfficeCalc",
+  },
+  ["odt"] = {
+    icon = "",
+    color = "#2DCBFD",
+    cterm_color = "81",
+    name = "LibreOfficeWriter",
+  },
   ["ogg"] = {
     icon = "",
     color = "#0075aa",
@@ -2809,6 +2863,12 @@ local icons_by_file_extension = {
     color = "#cb4a32",
     cterm_color = "160",
     name = "Ppt",
+  },
+  ["pptx"] = {
+    icon = "󰈧",
+    color = "#cb4a32",
+    cterm_color = "160",
+    name = "Pptx",
   },
   ["prisma"] = {
     icon = "",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1868,6 +1868,30 @@ local icons_by_file_extension = {
     cterm_color = "236",
     name = "Fennel",
   },
+  ["fodg"] = {
+    icon = "",
+    color = "#333211",
+    cterm_color = "236",
+    name = "LibreOfficeGraphics",
+  },
+  ["fodp"] = {
+    icon = "",
+    color = "#7f4e22",
+    cterm_color = "94",
+    name = "LibreOfficeImpress",
+  },
+  ["fods"] = {
+    icon = "",
+    color = "#28541a",
+    cterm_color = "22",
+    name = "LibreOfficeCalc",
+  },
+  ["fodt"] = {
+    icon = "",
+    color = "#16667e",
+    cterm_color = "24",
+    name = "LibreOfficeWriter",
+  },
   ["fs"] = {
     icon = "",
     color = "#36677c",
@@ -2690,6 +2714,36 @@ local icons_by_file_extension = {
     cterm_color = "240",
     name = "3DObjectFile",
   },
+  ["odf"] = {
+    icon = "",
+    color = "#aa3c64",
+    cterm_color = "125",
+    name = "LibreOfficeFormula",
+  },
+  ["odg"] = {
+    icon = "",
+    color = "#333211",
+    cterm_color = "236",
+    name = "LibreOfficeGraphics",
+  },
+  ["odp"] = {
+    icon = "",
+    color = "#7f4e22",
+    cterm_color = "94",
+    name = "LibreOfficeImpress",
+  },
+  ["ods"] = {
+    icon = "",
+    color = "#28541a",
+    cterm_color = "22",
+    name = "LibreOfficeCalc",
+  },
+  ["odt"] = {
+    icon = "",
+    color = "#16667e",
+    cterm_color = "24",
+    name = "LibreOfficeWriter",
+  },
   ["ogg"] = {
     icon = "",
     color = "#005880",
@@ -2809,6 +2863,12 @@ local icons_by_file_extension = {
     color = "#983826",
     cterm_color = "124",
     name = "Ppt",
+  },
+  ["pptx"] = {
+    icon = "󰈧",
+    color = "#983826",
+    cterm_color = "124",
+    name = "Pptx",
   },
   ["prisma"] = {
     icon = "",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -3893,6 +3893,12 @@ local icons_by_operating_system = {
     cterm_color = "24",
     name = "Kubuntu",
   },
+  ["leap"] = {
+    icon = "",
+    color = "#54421f",
+    cterm_color = "58",
+    name = "Leap",
+  },
   ["locos"] = {
     icon = "",
     color = "#7d5a01",
@@ -3934,6 +3940,12 @@ local icons_by_operating_system = {
     color = "#3d586e",
     cterm_color = "24",
     name = "NixOS",
+  },
+  ["nobara"] = {
+    icon = "",
+    color = "#333333",
+    cterm_color = "236",
+    name = "NobaraLinux",
   },
   ["openbsd"] = {
     icon = "",
@@ -4030,6 +4042,12 @@ local icons_by_operating_system = {
     color = "#0f58b6",
     cterm_color = "25",
     name = "TrisquelGNULinux",
+  },
+  ["tumbleweed"] = {
+    icon = "",
+    color = "#237b72",
+    cterm_color = "30",
+    name = "Tumbleweed",
   },
   ["ubuntu"] = {
     icon = "",
@@ -4168,6 +4186,12 @@ local icons_by_window_manager = {
     color = "#333333",
     cterm_color = "236",
     name = "Qtile",
+  },
+  ["river"] = {
+    icon = "",
+    color = "#000000",
+    cterm_color = "16",
+    name = "river",
   },
   ["sway"] = {
     icon = "",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -17,6 +17,30 @@ local icons_by_filename = {
     cterm_color = "22",
     name = "Bashrc",
   },
+  [".clang-format"] = {
+    icon = "",
+    color = "#526064",
+    cterm_color = "59",
+    name = "ClangConfig",
+  },
+  [".clang-tidy"] = {
+    icon = "",
+    color = "#526064",
+    cterm_color = "59",
+    name = "ClangConfig",
+  },
+  [".codespellrc"] = {
+    icon = "󰓆",
+    color = "#239140",
+    cterm_color = "28",
+    name = "Codespell",
+  },
+  [".condarc"] = {
+    icon = "",
+    color = "#2d751c",
+    cterm_color = "28",
+    name = "Conda",
+  },
   [".dockerignore"] = {
     icon = "󰡨",
     color = "#2e5f99",
@@ -107,6 +131,12 @@ local icons_by_filename = {
     cterm_color = "59",
     name = "Justfile",
   },
+  [".luacheckrc"] = {
+    icon = "",
+    color = "#007abf",
+    cterm_color = "32",
+    name = "Luaurc",
+  },
   [".luaurc"] = {
     icon = "",
     color = "#007abf",
@@ -118,6 +148,12 @@ local icons_by_filename = {
     color = "#b83a1d",
     cterm_color = "160",
     name = "Mailmap",
+  },
+  [".nanorc"] = {
+    icon = "",
+    color = "#440077",
+    cterm_color = "54",
+    name = "Nano",
   },
   [".npmignore"] = {
     icon = "",
@@ -142,6 +178,12 @@ local icons_by_filename = {
     color = "#3f6b34",
     cterm_color = "22",
     name = "node",
+  },
+  [".pre-commit-config.yaml"] = {
+    icon = "󰛢",
+    color = "#7c5a12",
+    cterm_color = "94",
+    name = "PreCommitConfig",
   },
   [".prettierrc"] = {
     icon = "",
@@ -202,6 +244,12 @@ local icons_by_filename = {
     color = "#3264b7",
     cterm_color = "25",
     name = "PrettierIgnore",
+  },
+  [".pylintrc"] = {
+    icon = "",
+    color = "#526064",
+    cterm_color = "59",
+    name = "PyLintConfig",
   },
   [".settings.json"] = {
     icon = "",
@@ -324,9 +372,9 @@ local icons_by_filename = {
     name = "Checkhealth",
   },
   ["cmakelists.txt"] = {
-    icon = "",
-    color = "#526064",
-    cterm_color = "59",
+    icon = "",
+    color = "#2c2d2f",
+    cterm_color = "236",
     name = "CMakeLists",
   },
   ["code_of_conduct"] = {
@@ -839,6 +887,18 @@ local icons_by_filename = {
     cterm_color = "52",
     name = "Rakefile",
   },
+  ["readme"] = {
+    icon = "󰂺",
+    color = "#2f2f2f",
+    cterm_color = "236",
+    name = "Readme",
+  },
+  ["readme.md"] = {
+    icon = "󰂺",
+    color = "#2f2f2f",
+    cterm_color = "236",
+    name = "Readme",
+  },
   ["rmd"] = {
     icon = "",
     color = "#36677c",
@@ -1311,9 +1371,9 @@ local icons_by_file_extension = {
     name = "ClojureDart",
   },
   ["cmake"] = {
-    icon = "",
-    color = "#526064",
-    cterm_color = "59",
+    icon = "",
+    color = "#2c2d2f",
+    cterm_color = "236",
     name = "CMake",
   },
   ["cob"] = {
@@ -1333,6 +1393,12 @@ local icons_by_file_extension = {
     color = "#666620",
     cterm_color = "58",
     name = "Coffee",
+  },
+  ["conda"] = {
+    icon = "",
+    color = "#2d751c",
+    cterm_color = "28",
+    name = "Conda",
   },
   ["conf"] = {
     icon = "",
@@ -1772,6 +1838,12 @@ local icons_by_file_extension = {
     cterm_color = "23",
     name = "Fdmdownload",
   },
+  ["fish"] = {
+    icon = "",
+    color = "#3a4446",
+    cterm_color = "238",
+    name = "Fish",
+  },
   ["flac"] = {
     icon = "",
     color = "#005880",
@@ -1795,12 +1867,6 @@ local icons_by_file_extension = {
     color = "#33312b",
     cterm_color = "236",
     name = "Fennel",
-  },
-  ["fish"] = {
-    icon = "",
-    color = "#3a4446",
-    cterm_color = "238",
-    name = "Fish",
   },
   ["fs"] = {
     icon = "",
@@ -2127,9 +2193,9 @@ local icons_by_file_extension = {
     name = "Iso",
   },
   ["ipynb"] = {
-    icon = "",
-    color = "#366b8a",
-    cterm_color = "24",
+    icon = "",
+    color = "#a35301",
+    cterm_color = "130",
     name = "Notebook",
   },
   ["java"] = {
@@ -3380,6 +3446,12 @@ local icons_by_file_extension = {
     cterm_color = "94",
     name = "Txz",
   },
+  ["typ"] = {
+    icon = "",
+    color = "#097d80",
+    cterm_color = "30",
+    name = "Typst",
+  },
   ["typoscript"] = {
     icon = "",
     color = "#aa5a00",
@@ -3405,8 +3477,8 @@ local icons_by_file_extension = {
     name = "Verilog",
   },
   ["vala"] = {
-    icon = "",
-    color = "#562b86",
+    icon = "",
+    color = "#5c2e8b",
     cterm_color = "54",
     name = "Vala",
   },
@@ -3427,6 +3499,12 @@ local icons_by_file_extension = {
     color = "#017226",
     cterm_color = "22",
     name = "VHDL",
+  },
+  ["vi"] = {
+    icon = "",
+    color = "#554203",
+    cterm_color = "58",
+    name = "LabView",
   },
   ["vim"] = {
     icon = "",


### PR DESCRIPTION
Using new glyphs from Nerd Fonts 3.3.0 release: https://github.com/ryanoasis/nerd-fonts/releases/tag/v3.3.0

LibreOffice colors got from accent colors: https://wiki.documentfoundation.org/Design/Branding

```shell
touch .clang-{format,tidy} .condarc .luacheckrc .nanorc .pre-commit-config.yaml .pylintrc cmakelists.txt README{,.md} file.{cmake,conda,ipynb,typ,vala,vi}
touch file.{{f,}{odp,odt,ods,odg},odf}
```
This pull request includes a series of updates to the `nvim-web-devicons` plugin, specifically adding new file and operating system icons, and updating existing ones. The changes span across the `icons-default.lua` and `icons-light.lua` files.
| 1 | 2 |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/bebe1601-fe1b-4126-82cb-6844216f95c8) | ![image](https://github.com/user-attachments/assets/0e957b57-1608-4707-8086-1a663b8e6de3) | 


---

### Additions of new icons:
* Added icons for various configuration files such as `.clang-format`, `.clang-tidy`, `.codespellrc`, `.condarc`, `.luacheckrc`, `.nanorc`, `.pre-commit-config.yaml`, and `.pylintrc`. [[1]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eR20-R43) [[2]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eR134-R139) [[3]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eR152-R157) [[4]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eR182-R187) [[5]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eR248-R253) [[6]](diffhunk://#diff-7a23300d4769cf898d89d0053d1a473cee92953e8e42c0addffbd247b30c16e2R20-R43) [[7]](diffhunk://#diff-7a23300d4769cf898d89d0053d1a473cee92953e8e42c0addffbd247b30c16e2R134-R139) [[8]](diffhunk://#diff-7a23300d4769cf898d89d0053d1a473cee92953e8e42c0addffbd247b30c16e2R152-R157) [[9]](diffhunk://#diff-7a23300d4769cf898d89d0053d1a473cee92953e8e42c0addffbd247b30c16e2R182-R187) [[10]](diffhunk://#diff-7a23300d4769cf898d89d0053d1a473cee92953e8e42c0addffbd247b30c16e2R248-R253)

### Updates to existing icons:
* Updated the icon for `CMakeLists.txt` and files with the `.cmake` extension to a new design. [[1]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eL327-R377) [[2]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eL1314-R1376) [[3]](diffhunk://#diff-7a23300d4769cf898d89d0053d1a473cee92953e8e42c0addffbd247b30c16e2L327-R377) [[4]](diffhunk://#diff-7a23300d4769cf898d89d0053d1a473cee92953e8e42c0addffbd247b30c16e2L1314-R1376)
* Updated the icon for files with the `.ipynb` extension (Jupyter Notebooks). [[1]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eL2130-R2222) [[2]](diffhunk://#diff-7a23300d4769cf898d89d0053d1a473cee92953e8e42c0addffbd247b30c16e2L2130-R2222)

### Additions of new file extensions:
* Added icons for LibreOffice file formats including `.fodg`, `.fodp`, `.fods`, `.fodt`, `.odf`, `.odg`, `.odp`, `.ods`, and `.odt`. [[1]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eL1799-R1893) [[2]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eR2717-R2746) [[3]](diffhunk://#diff-7a23300d4769cf898d89d0053d1a473cee92953e8e42c0addffbd247b30c16e2L1799-R1893) [[4]](diffhunk://#diff-7a23300d4769cf898d89d0053d1a473cee92953e8e42c0addffbd247b30c16e2R2717-R2746)
* Added icons for `.pptx` files. [[1]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eR2867-R2872) [[2]](diffhunk://#diff-7a23300d4769cf898d89d0053d1a473cee92953e8e42c0addffbd247b30c16e2R2867-R2872)

### Additions of new operating system icons:
* Added icons for Leap, Nobara Linux, and Tumbleweed. [[1]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eR3956-R3961) [[2]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eR4004-R4009) [[3]](diffhunk://#diff-1e8785e68692ab103bcc688a5dc526821182e0bbdb9121cfdcf8b8b2e6ebf44eR4106-R4111)

### Additions of new window manager icons:
* Added an icon for the River window manager.