### PR TITLE
style: Update D lang color

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1535,7 +1535,7 @@ local icons_by_file_extension = {
   ["d"] = {
     icon = "",
     color = "#b03931",
-    cterm_color = "88",
+    cterm_color = "124",
     name = "D",
   },
   ["d.ts"] = {

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1534,8 +1534,8 @@ local icons_by_file_extension = {
   },
   ["d"] = {
     icon = "",
-    color = "#427819",
-    cterm_color = "28",
+    color = "#b03931",
+    cterm_color = "88",
     name = "D",
   },
   ["d.ts"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1534,8 +1534,8 @@ local icons_by_file_extension = {
   },
   ["d"] = {
     icon = "",
-    color = "#325a13",
-    cterm_color = "22",
+    color = "#b03931",
+    cterm_color = "52",
     name = "D",
   },
   ["d.ts"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1535,7 +1535,7 @@ local icons_by_file_extension = {
   ["d"] = {
     icon = "",
     color = "#b03931",
-    cterm_color = "52",
+    cterm_color = "88",
     name = "D",
   },
   ["d.ts"] = {

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1534,7 +1534,7 @@ local icons_by_file_extension = {
   },
   ["d"] = {
     icon = "",
-    color = "#b03931",
+    color = "#842b25",
     cterm_color = "88",
     name = "D",
   },


### PR DESCRIPTION
Changed color for the D programming language icon from dark green to the official dark red (#b03931), along with the cterm color to a similar dark red.

Edit: Light mode color has been updated to (#842b25), which was provided by the color check CI.