### PR TITLE
fix: update `vercel.json` glyph from Unicode to Nerd Fonts

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -1002,7 +1002,7 @@ local icons_by_filename = {
     name = "VLC",
   },
   ["vercel.json"] = {
-    icon = "▲",
+    icon = "",
     color = "#ffffff",
     cterm_color = "231",
     name = "Vercel",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -1002,7 +1002,7 @@ local icons_by_filename = {
     name = "VLC",
   },
   ["vercel.json"] = {
-    icon = "▲",
+    icon = "",
     color = "#333333",
     cterm_color = "236",
     name = "Vercel",


### PR DESCRIPTION
Nerd Font glyph is bigger.

![2024-12-12-192551_hyprshot](https://github.com/user-attachments/assets/33391ea5-8f32-4c67-a4fa-64e491bd7943)
