### PR TITLE
fix: update Gemfile and valgrant files incorrect definitions

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -515,7 +515,7 @@ local icons_by_filename = {
     cterm_color = "160",
     name = "FreeCADConfig",
   },
-  ["gemfile$"] = {
+  ["Gemfile"] = {
     icon = "",
     color = "#701516",
     cterm_color = "52",
@@ -989,7 +989,7 @@ local icons_by_filename = {
     cterm_color = "185",
     name = "License",
   },
-  ["vagrantfile$"] = {
+  ["vagrantfile"] = {
     icon = "",
     color = "#1563FF",
     cterm_color = "27",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -515,7 +515,7 @@ local icons_by_filename = {
     cterm_color = "88",
     name = "FreeCADConfig",
   },
-  ["gemfile$"] = {
+  ["Gemfile"] = {
     icon = "",
     color = "#701516",
     cterm_color = "52",
@@ -989,7 +989,7 @@ local icons_by_filename = {
     cterm_color = "58",
     name = "License",
   },
-  ["vagrantfile$"] = {
+  ["vagrantfile"] = {
     icon = "",
     color = "#104abf",
     cterm_color = "26",


### PR DESCRIPTION
Fixes #510 

Updated the definitions of the `gemfile` and `vagrantfile` by removing the unused `$` sign. 

## Before fix
![Screenshot 2024-12-14 185616](https://github.com/user-attachments/assets/64da6b2d-797c-44a4-9183-f221bc4c5b1e)

## After fix
![Screenshot 2024-12-14 185356](https://github.com/user-attachments/assets/6698a57a-e76d-4b95-8632-c11f6b8e2860)
