### PR TITLE
feat: add icons for AUTHORS{,.txt} and index.theme files

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -323,6 +323,18 @@ local icons_by_filename = {
     cterm_color = "28",
     name = "Vimrc",
   },
+  ["AUTHORS"] = {
+    icon = "",
+    color = "#A172FF",
+    cterm_color = "135",
+    name = "AUTHORS",
+  },
+  ["AUTHORS.txt"] = {
+    icon = "",
+    color = "#A172FF",
+    cterm_color = "135",
+    name = "AUTHORS",
+  },
   ["avif"] = {
     icon = "",
     color = "#a074c4",
@@ -670,6 +682,12 @@ local icons_by_filename = {
     color = "#e8ebee",
     cterm_color = "255",
     name = "i3",
+  },
+  ["index.theme"] = {
+    icon = "",
+    color = "#2DB96F",
+    cterm_color = "35",
+    name = "IndexTheme",
   },
   ["ionic.config.json"] = {
     icon = "",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -323,6 +323,18 @@ local icons_by_filename = {
     cterm_color = "22",
     name = "Vimrc",
   },
+  ["AUTHORS"] = {
+    icon = "",
+    color = "#6b4caa",
+    cterm_color = "61",
+    name = "AUTHORS",
+  },
+  ["AUTHORS.txt"] = {
+    icon = "",
+    color = "#6b4caa",
+    cterm_color = "61",
+    name = "AUTHORS",
+  },
   ["avif"] = {
     icon = "",
     color = "#6b4d83",
@@ -670,6 +682,12 @@ local icons_by_filename = {
     color = "#2e2f30",
     cterm_color = "236",
     name = "i3",
+  },
+  ["index.theme"] = {
+    icon = "",
+    color = "#1e7b4a",
+    cterm_color = "29",
+    name = "IndexTheme",
   },
   ["ionic.config.json"] = {
     icon = "",


### PR DESCRIPTION
AUTHORS is common on some projects and `index.theme`[^1] appear on icon themes like MoreWaita

![image](https://github.com/user-attachments/assets/98f01e42-7af0-43bf-9997-31fbdc5d4ca5)

[^1]: https://specifications.freedesktop.org/icon-theme-spec/latest/