### PR TITLE
Add missing dockerfile and dockercompose icons

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -462,14 +462,14 @@ local icons_by_filename = {
     name = "Dockerfile",
   },
   ["docker-compose.yml"] = {
-    icon = "󰡨",
-    color = "#458ee6",
+    icon = "",
+    color = "#0db7ed",
     cterm_color = "68",
     name = "Dockerfile",
   },
   ["dockerfile"] = {
-    icon = "󰡨",
-    color = "#458ee6",
+    icon = "/",
+    color = "#0db7ed",
     cterm_color = "68",
     name = "Dockerfile",
   },

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -462,15 +462,15 @@ local icons_by_filename = {
     name = "Dockerfile",
   },
   ["docker-compose.yml"] = {
-    icon = "󰡨",
-    color = "#2e5f99",
-    cterm_color = "25",
+    icon = "",
+    color = "#0db7ed",
+    cterm_color = "68",
     name = "Dockerfile",
   },
   ["dockerfile"] = {
-    icon = "󰡨",
-    color = "#2e5f99",
-    cterm_color = "25",
+    icon = "/",
+    color = "#0db7ed",
+    cterm_color = "68",
     name = "Dockerfile",
   },
   ["eslint.config.cjs"] = {


### PR DESCRIPTION
After opening Nerdtree with latest nvim version I was not seeing dockerfile and dockercompose icons maybe older icons were incompatible with latest version of nerdfonts