### PR TITLE
feat: add slnx icon

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -3246,7 +3246,7 @@ local icons_by_file_extension = {
     icon = "",
     color = "#854CC7",
     cterm_color = "98",
-    name = "Sln",
+    name = "Slnx",
   },
   ["slvs"] = {
     icon = "󰻫",

--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -3242,6 +3242,12 @@ local icons_by_file_extension = {
     cterm_color = "98",
     name = "Sln",
   },
+  ["slnx"] = {
+    icon = "",
+    color = "#854CC7",
+    cterm_color = "98",
+    name = "Sln",
+  },
   ["slvs"] = {
     icon = "󰻫",
     color = "#839463",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -3242,6 +3242,12 @@ local icons_by_file_extension = {
     cterm_color = "91",
     name = "Sln",
   },
+  ["slnx"] = {
+    icon = "",
+    color = "#643995",
+    cterm_color = "91",
+    name = "Slnx",
+  },
   ["slvs"] = {
     icon = "󰻫",
     color = "#576342",


### PR DESCRIPTION
Added icon for the new dotnet solution file format. Slnx. This also represents a solution as the normal .sln extension so it makes sense to give it the same icon

reference: https://github.com/vim/vim/pull/16334

