### PR TITLE
feat: add msbuild configuration icons

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -473,6 +473,24 @@ local icons_by_filename = {
     cterm_color = "68",
     name = "Dockerfile",
   },
+  ["Directory.Packages.props"] = {
+    icon = "",
+    color = "#00a2ff",
+    cterm_color = "75",
+    name = "PackagesProps",
+  },
+  ["Directory.Build.targets"] = {
+    icon = "",
+    color = "#00a2ff",
+    cterm_color = "75",
+    name = "BuildTargets",
+  },
+  ["Directory.Build.props"] = {
+    icon = "",
+    color = "#00a2ff",
+    cterm_color = "75",
+    name = "BuildProps",
+  },
   ["eslint.config.cjs"] = {
     icon = "",
     color = "#4b32c3",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -473,6 +473,24 @@ local icons_by_filename = {
     cterm_color = "25",
     name = "Dockerfile",
   },
+  ["Directory.Packages.props"] = {
+    icon = "",
+    color = "#007abf",
+    cterm_color = "32",
+    name = "PackagesProps",
+  },
+  ["Directory.Build.targets"] = {
+    icon = "",
+    color = "#007abf",
+    cterm_color = "32",
+    name = "BuildTargets",
+  },
+  ["Directory.Build.props"] = {
+    icon = "",
+    color = "#007abf",
+    cterm_color = "32",
+    name = "BuildProps",
+  },
   ["eslint.config.cjs"] = {
     icon = "",
     color = "#4b32c3",


### PR DESCRIPTION
Adds icons for msbuild configuration files

reference: https://github.com/vim/vim/pull/16339