### PR TITLE
feat: add more ogg formats

### DIFF
--- a/lua/nvim-web-devicons/icons-default.lua
+++ b/lua/nvim-web-devicons/icons-default.lua
@@ -2798,11 +2798,29 @@ local icons_by_file_extension = {
     cterm_color = "81",
     name = "LibreOfficeWriter",
   },
+  ["oga"] = {
+    icon = "",
+    color = "#0075aa",
+    cterm_color = "24",
+    name = "OggVorbis",
+  },
   ["ogg"] = {
     icon = "",
     color = "#0075aa",
     cterm_color = "24",
     name = "OggVorbis",
+  },
+  ["ogv"] = {
+    icon = "",
+    color = "#FD971F",
+    cterm_color = "208",
+    name = "OggVideo",
+  },
+  ["ogx"] = {
+    icon = "",
+    color = "#FD971F",
+    cterm_color = "208",
+    name = "OggMultiplex",
   },
   ["opus"] = {
     icon = "",
@@ -3313,6 +3331,12 @@ local icons_by_file_extension = {
     color = "#1354bf",
     cterm_color = "26",
     name = "TypeScriptReactSpec",
+  },
+  ["spx"] = {
+    icon = "",
+    color = "#0075aa",
+    cterm_color = "24",
+    name = "OggSpeexAudio",
   },
   ["sql"] = {
     icon = "",

--- a/lua/nvim-web-devicons/icons-light.lua
+++ b/lua/nvim-web-devicons/icons-light.lua
@@ -2798,11 +2798,29 @@ local icons_by_file_extension = {
     cterm_color = "24",
     name = "LibreOfficeWriter",
   },
+  ["oga"] = {
+    icon = "",
+    color = "#005880",
+    cterm_color = "24",
+    name = "OggVorbis",
+  },
   ["ogg"] = {
     icon = "",
     color = "#005880",
     cterm_color = "24",
     name = "OggVorbis",
+  },
+  ["ogv"] = {
+    icon = "",
+    color = "#7e4c10",
+    cterm_color = "94",
+    name = "OggVideo",
+  },
+  ["ogx"] = {
+    icon = "",
+    color = "#7e4c10",
+    cterm_color = "94",
+    name = "OggMultiplex",
   },
   ["opus"] = {
     icon = "",
@@ -3313,6 +3331,12 @@ local icons_by_file_extension = {
     color = "#1354bf",
     cterm_color = "26",
     name = "TypeScriptReactSpec",
+  },
+  ["spx"] = {
+    icon = "",
+    color = "#005880",
+    cterm_color = "24",
+    name = "OggSpeexAudio",
   },
   ["sql"] = {
     icon = "",


### PR DESCRIPTION
The `ogx` file extension is a container that can contain any Ogg format, so I'm not sure if it should be classified as a video, as it seems to be more like an archive, but for Ogg formats.

Source:
https://wiki.xiph.org/index.php/MIME_Types_and_File_Extensions

Follow up to https://github.com/sxyazi/yazi/pull/2136.