### PR TITLE
chore: replace deprecated neovim API

### DIFF
--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -346,14 +346,18 @@ local function set_up_highlight(icon_data)
   end
 end
 
-local nvim_get_hl_by_name = vim.api.nvim_get_hl_by_name
 local function highlight_exists(group)
   if not group then
     return
   end
 
-  local ok, hl = pcall(nvim_get_hl_by_name, group, true)
-  return ok and not (hl or {})[true]
+  if vim.fn.has "nvim-0.9" == 1 then
+    local hl = vim.api.nvim_get_hl(0, { name = group, link = false })
+    return not vim.tbl_isempty(hl)
+  else
+    local ok, hl = pcall(vim.api.nvim_get_hl_by_name, group, true) ---@diagnostic disable-line: deprecated
+    return ok and not (hl or {})[true]
+  end
 end
 
 function M.set_up_highlights(allow_override)
@@ -377,7 +381,16 @@ local function get_highlight_foreground(icon_data)
     icon_data = default_icon
   end
 
-  return string.format("#%06x", nvim_get_hl_by_name(get_highlight_name(icon_data), true).foreground)
+  local higroup = get_highlight_name(icon_data)
+
+  local fg
+  if vim.fn.has "nvim-0.9" == 1 then
+    fg = vim.api.nvim_get_hl(0, { name = higroup, link = false }).fg
+  else
+    fg = vim.api.nvim_get_hl_by_name(higroup, true).foreground ---@diagnostic disable-line: deprecated
+  end
+
+  return string.format("#%06x", fg)
 end
 
 local function get_highlight_ctermfg(icon_data)
@@ -385,7 +398,14 @@ local function get_highlight_ctermfg(icon_data)
     icon_data = default_icon
   end
 
-  return nvim_get_hl_by_name(get_highlight_name(icon_data), false).foreground
+  local higroup = get_highlight_name(icon_data)
+
+  if vim.fn.has "nvim-0.9" == 1 then
+    --- @diagnostic disable-next-line: undefined-field  vim.api.keyset.hl_info specifies cterm, not ctermfg
+    return vim.api.nvim_get_hl(0, { name = higroup, link = false }).ctermfg
+  else
+    return vim.api.nvim_get_hl_by_name(higroup, false).foreground ---@diagnostic disable-line: deprecated
+  end
 end
 
 local loaded = false


### PR DESCRIPTION
We should raise the minimum version of nvim to 0.9 or 0.10 at some point