### PR TITLE
chore: replace deprecated neovim API

### DIFF
--- a/lua/nvim-web-devicons/hi-test.lua
+++ b/lua/nvim-web-devicons/hi-test.lua
@@ -131,7 +131,7 @@ return function(
   render_icons(bufnr, l, icons_by_window_manager, "By Window Manager")
 
   -- finalise and focus the buffer
-  if vim.fn.has("nvim-0.10") == 1 then
+  if vim.fn.has "nvim-0.10" == 1 then
     vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
   else
     vim.api.nvim_buf_set_option(bufnr, "modifiable", false) ---@diagnostic disable-line: deprecated

--- a/lua/nvim-web-devicons/hi-test.lua
+++ b/lua/nvim-web-devicons/hi-test.lua
@@ -131,6 +131,10 @@ return function(
   render_icons(bufnr, l, icons_by_window_manager, "By Window Manager")
 
   -- finalise and focus the buffer
-  vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
+  if vim.fn.has("nvim-0.10") == 1 then
+    vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+  else
+    vim.api.nvim_buf_set_option(bufnr, "modifiable", false) ---@diagnostic disable-line: deprecated
+  end
   vim.cmd.buffer(bufnr)
 end


### PR DESCRIPTION
Missed one in #553 

This project is not yet in a state to properly enforce luals like nvim-tree does.

We can gradually introduce the Icon class and clean, or just rewrite `nvim-web-devicons.lua`