### PR TITLE
feat: add Jenkinsfile Icon

### DIFF
--- a/lua/nvim-web-devicons/default/icons_by_filename.lua
+++ b/lua/nvim-web-devicons/default/icons_by_filename.lua
@@ -58,6 +58,7 @@ return {
   ["Directory.Packages.props"]   = { icon = "", color = "#00A2FF", cterm_color = "75",  name = "PackagesProps"           },
   ["FreeCAD.conf"]               = { icon = "", color = "#CB333B", cterm_color = "160", name = "FreeCADConfig"           },
   ["Gemfile"]                    = { icon = "", color = "#701516", cterm_color = "52",  name = "Gemfile"                 },
+  ["Jenkinsfile"]                = { icon = "", color = "#D33833", cterm_color = "160", name = "Jenkins"                 },
   ["PKGBUILD"]                   = { icon = "", color = "#0F94D2", cterm_color = "67",  name = "PKGBUILD"                },
   ["PrusaSlicer.ini"]            = { icon = "", color = "#EC6B23", cterm_color = "202", name = "PrusaSlicer"             },
   ["PrusaSlicerGcodeViewer.ini"] = { icon = "", color = "#EC6B23", cterm_color = "202", name = "PrusaSlicer"             },

--- a/lua/nvim-web-devicons/light/icons_by_filename.lua
+++ b/lua/nvim-web-devicons/light/icons_by_filename.lua
@@ -58,6 +58,7 @@ return { -- this file is generated from lua/nvim-web-devicons/default/icons_by_f
   ["Directory.Packages.props"]   = { icon = "", color = "#007ABF", cterm_color = "32",  name = "PackagesProps"           },
   ["FreeCAD.conf"]               = { icon = "", color = "#98262C", cterm_color = "88",  name = "FreeCADConfig"           },
   ["Gemfile"]                    = { icon = "", color = "#701516", cterm_color = "52",  name = "Gemfile"                 },
+  ["Jenkinsfile"]                = { icon = "", color = "#9E2A26", cterm_color = "124", name = "Jenkins"                 },
   ["PKGBUILD"]                   = { icon = "", color = "#0B6F9E", cterm_color = "24",  name = "PKGBUILD"                },
   ["PrusaSlicer.ini"]            = { icon = "", color = "#9D4717", cterm_color = "130", name = "PrusaSlicer"             },
   ["PrusaSlicerGcodeViewer.ini"] = { icon = "", color = "#9D4717", cterm_color = "130", name = "PrusaSlicer"             },


### PR DESCRIPTION
### Overview

This PR adds an icon for [`Jenkinsfile`](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/).

The icon uses the Jenkins Nerd Font glyph, with the color chosen to match the bowtie (and background) from the official Jenkins logo.

I also considered going for white (`#FFFFFF`), but I'm not sure if it looks better, let me know if you prefer the white version, so I could change it.

#### Red Version:
<img width="386" height="126" alt="image" src="https://github.com/user-attachments/assets/6267ca47-f1df-43b0-be6e-e458f3ff86e5" />



#### White Version:
<img width="382" height="124" alt="image" src="https://github.com/user-attachments/assets/3a9b85e8-a762-45a8-9c3c-1613bad8d957" />
